### PR TITLE
fix: align Play manager controls across viewports

### DIFF
--- a/src/nitro_ai_judge_cli/manager/assets/app.css
+++ b/src/nitro_ai_judge_cli/manager/assets/app.css
@@ -67,6 +67,7 @@ button:focus-visible, input:focus-visible, select:focus-visible, summary:focus-v
 main { width: min(1440px, 100%); margin: 0 auto; padding: 34px clamp(20px, 5vw, 72px) 64px; flex: 1; }
 .toolbar { display: grid; grid-template-columns: minmax(260px, 2fr) minmax(150px, .7fr) minmax(170px, .8fr) auto; gap: 14px; align-items: end; }
 .toolbar-actions { display: flex; gap: 8px; }
+.toolbar-actions button { height: 43px; min-height: 43px; }
 label, .filter-field { display: grid; gap: 7px; color: var(--muted); font-weight: 650; font-size: .78rem; }
 input { width: 100%; min-height: 43px; padding: 9px 11px; color: var(--ink); background: var(--surface); border: 1px solid var(--line); border-radius: 5px; }
 input:hover { border-color: var(--muted); }
@@ -121,8 +122,8 @@ th:last-child, td.actions { text-align: right; }
 .status[data-state="pulling"], .status[data-state="starting"], .status[data-state="stopped"], .status[data-state="fallback"] { color: var(--warn); }
 .status[data-state="error"], .status[data-state="unhealthy"] { color: var(--bad); }
 .status[data-state="missing"], .status[data-state="unknown"] { color: var(--muted); }
-.actions { display: flex; min-width: 215px; flex-wrap: wrap; gap: 7px; align-items: center; justify-content: flex-end; }
-.actions .action-button { height: 34px; min-height: 34px; }
+.actions { display: flex; min-width: 215px; flex-wrap: nowrap; gap: 7px; align-items: center; justify-content: flex-end; }
+.actions .action-button { height: 34px; min-height: 34px; white-space: nowrap; }
 .operation-row td { padding: 0; border-top: 0; }
 .operation-row[hidden] { display: none; }
 .operation { border-left: 4px solid var(--accent); padding: 13px 18px 16px; background: color-mix(in srgb, var(--accent) 7%, var(--surface)); }
@@ -201,7 +202,7 @@ dialog p { margin: 0; }
   .competition-row td:first-child::before { content: none; }
   .competition-row td.actions { display: grid; min-width: 0; grid-template-columns: 95px minmax(0, 1fr); gap: 7px; }
   .actions::before { grid-column: 1; grid-row: 1 / -1; }
-  .actions .action-button { width: 100%; grid-column: 2; white-space: nowrap; }
+  .actions .action-button { width: 100%; grid-column: 2; }
   .operation-row { margin: -14px 0 14px; }
   .operation-row td { border: 0; }
   .operation-heading, .operation-heading > div:first-child, .live-alert { align-items: stretch; flex-direction: column; }

--- a/src/nitro_ai_judge_cli/manager/assets/app.js
+++ b/src/nitro_ai_judge_cli/manager/assets/app.js
@@ -141,6 +141,7 @@
       if (["queued", "running"].includes(operation.status)) return "pulling";
       if (operation.status === "failed") return "error";
     }
+    if (competition.image_state === "ready" && Object.values(competition.images || {}).some(image => image.fallback)) return "fallback";
     return competition.image_state;
   }
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1342,6 +1342,7 @@ class ManagerRouteTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn('return "pulling"', script)
         self.assertIn('operation.status === "failed"', script)
         self.assertIn('return "error"', script)
+        self.assertIn('some(image => image.fallback)) return "fallback"', script)
         self.assertIn("effectiveImageState(item) === imageFilter.dataset.value", script)
         self.assertIn("status(imageStatus, effectiveImageState(competition))", script)
         self.assertIn(


### PR DESCRIPTION
## Summary

- align Clear operations and Refresh with the 43px search/filter controls
- keep desktop table actions on one line and rely on the ledger scroll area at narrower widths
- preserve the stacked card actions at 660px and below
- show ready fallback images as Fallback while preserving pulling and error operation states

## Verification

- Chromium at 1440px and 1280px: all five running-workspace actions stayed on one row; toolbar controls shared 43px edges
- Chromium at 850px and 700px: actions stayed together; ledger scroll widths were 867px versus 765px and 630px viewports, exposing every action without clipping
- Chromium at 660px and 375px: the action cell switched to the card grid and all five equal-width buttons stacked cleanly
- rebuilt and reinstalled naij-play-manager:dev; the live nitro/rise-2026-final row rendered text and data-state as fallback with its fallback-source tooltip
- uv run --extra manager python3 -m unittest tests.test_manager -v: 51 passed