### PR TITLE
Fix submission pagination, rendering, and resumable waits

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Submit options:
 - `-s`, `--source`: optional source file
 - `-n`, `--note`: submission note
 - `-w`, `--wait`: wait for judging feedback
+- `--wait-timeout`: maximum wait in seconds (default: 180)
 
 Submission-list options:
 
@@ -214,6 +215,8 @@ Submission-list options:
 - `-m`, `--mode`: `partial`, `complete`, or `both`
 
 Use `naij set-final [SUBMISSION]` and `naij unset-final [SUBMISSION]` to change the final selection. The submission argument may be omitted when one is selected in the interactive shell.
+
+Resume waiting after an interrupted submission with `naij submission [SUBMISSION] --wait`; the ID may be omitted when a submission is selected.
 
 ## Backend and submission proxy
 

--- a/src/nitro_ai_judge_cli/cli.py
+++ b/src/nitro_ai_judge_cli/cli.py
@@ -23,7 +23,13 @@ from .contests import (
     print_competitions,
     task_number,
 )
-from .play import PLAY_ACTIONS, add_play_parser, cmd_play, normalize_play_argv
+from .play import (
+    PLAY_ACTIONS,
+    add_play_parser,
+    cmd_play,
+    normalize_play_argv,
+    positive_seconds,
+)
 from .shell import run_shell
 from .state import (
     CredentialsError,
@@ -298,6 +304,7 @@ def build_parser() -> argparse.ArgumentParser:
     submit.add_argument("-s", "--source")
     submit.add_argument("-n", "--note", default="")
     submit.add_argument("-w", "--wait", action="store_true")
+    submit.add_argument("--wait-timeout", type=positive_seconds, default=180)
 
     submissions = sub.add_parser("submissions", help="List submissions for a task")
     submissions.add_argument("targets", nargs="*", help="[competition] [task]")
@@ -311,6 +318,8 @@ def build_parser() -> argparse.ArgumentParser:
     submission.add_argument("--org")
     submission.add_argument("--comp")
     submission.add_argument("--task-id")
+    submission.add_argument("-w", "--wait", action="store_true")
+    submission.add_argument("--wait-timeout", type=positive_seconds, default=180)
 
     for name, help_text in (("set-final", "Mark a submission as final"), ("unset-final", "Unmark a submission as final")):
         command = sub.add_parser(name, help=help_text)
@@ -390,7 +399,11 @@ def _dispatch_authenticated(args: argparse.Namespace) -> int:
         elif args.cmd == "submit":
             result = cmd_submit(
                 cookies, bearer, org, comp, task_id,
-                args.output, args.source, args.note, args.wait,
+                args.output,
+                args.source,
+                args.note,
+                args.wait,
+                args.wait_timeout,
             )
         else:
             result = cmd_submissions(
@@ -416,6 +429,8 @@ def _dispatch_authenticated(args: argparse.Namespace) -> int:
             org=args.org or (contest[0] if contest else None),
             comp=args.comp or (contest[1] if contest else None),
             task_id=args.task_id or selected_task(context),
+            wait=args.wait,
+            wait_timeout=args.wait_timeout,
         )
 
     if args.cmd in {"set-final", "unset-final"}:

--- a/src/nitro_ai_judge_cli/completion.py
+++ b/src/nitro_ai_judge_cli/completion.py
@@ -42,13 +42,16 @@ OPTION_GROUPS = {
     ),
     "submit": (
         ("-o", "--output"), ("-s", "--source"), ("-n", "--note"),
-        ("-w", "--wait"), ("--help",),
+        ("-w", "--wait"), ("--wait-timeout",), ("--help",),
     ),
     "submissions": (
         ("-a", "--author"), ("-p", "--page"), ("-n", "--page-size"),
         ("-m", "--mode"), ("--help",),
     ),
-    "submission": (("--org",), ("--comp",), ("--task-id",), ("--help",)),
+    "submission": (
+        ("--org",), ("--comp",), ("--task-id",), ("-w", "--wait"),
+        ("--wait-timeout",), ("--help",),
+    ),
     "set-final": (("--help",),),
     "unset-final": (("--help",),),
     "use": (("--clear",), ("--help",)),
@@ -92,11 +95,14 @@ VALUE_OPTIONS = {
         "--port", "--bind", "--pull", "--wait-timeout", "--tail", "--image",
         "--tls-cert", "--tls-key", "--public-url",
     },
-    "submit": {"-o", "--output", "-s", "--source", "-n", "--note"},
+    "submit": {
+        "-o", "--output", "-s", "--source", "-n", "--note",
+        "--wait-timeout",
+    },
     "submissions": {
         "-a", "--author", "-p", "--page", "-n", "--page-size", "-m", "--mode",
     },
-    "submission": {"--org", "--comp", "--task-id"},
+    "submission": {"--org", "--comp", "--task-id", "--wait-timeout"},
 }
 REPEATABLE_OPTION_GROUPS = {"download-data": {"-c"}}
 

--- a/src/nitro_ai_judge_cli/submissions.py
+++ b/src/nitro_ai_judge_cli/submissions.py
@@ -13,6 +13,19 @@ from .config import DEFAULT_SUBMISSION_PAGE_SIZE
 from .state import load_state, update_cache
 from .ui import format_datetime_ms
 
+
+class SubmissionWaitTimeout(RuntimeError):
+    pass
+
+
+def _submission_id(value: dict[str, Any]) -> str:
+    return str(
+        value.get("submissionID")
+        or value.get("submissionId")
+        or value.get("id")
+        or ""
+    )
+
 def get_username(state: dict[str, Any] | None) -> str:
     return (state or {}).get("username") or ""
 
@@ -22,11 +35,7 @@ def _submission_response(status: int, body: str) -> dict[str, Any]:
     parsed = body_json(body)
     if not isinstance(parsed, dict):
         raise RuntimeError("Could not parse submission response")
-    if not (
-        parsed.get("submissionID")
-        or parsed.get("submissionId")
-        or parsed.get("id")
-    ):
+    if not _submission_id(parsed):
         raise RuntimeError("Submission response did not contain an ID")
     return parsed
 
@@ -221,7 +230,7 @@ def load_submissions(
             return parsed, 1
         if not isinstance(parsed, dict):
             return None
-        items = (
+        items_container = (
             parsed.get("data")
             or parsed.get("items")
             or parsed.get("submissions")
@@ -230,11 +239,19 @@ def load_submissions(
             )
             or []
         )
-        if isinstance(items, dict):
-            items = items.get("data") or items.get("items") or []
+        items = items_container
+        if isinstance(items_container, dict):
+            items = items_container.get("data") or items_container.get("items") or []
         if not isinstance(items, list):
             return None
-        last_page = int(parsed.get("lastPage") or parsed.get("last_page") or 1)
+        pagination = items_container if isinstance(items_container, dict) else parsed
+        last_page = int(
+            pagination.get("lastPage")
+            or pagination.get("last_page")
+            or parsed.get("lastPage")
+            or parsed.get("last_page")
+            or 1
+        )
         return items, max(last_page, 1)
 
     if page is not None:
@@ -323,29 +340,25 @@ def print_submission_details(submission: dict[str, Any]) -> None:
         print(f"Complete Score: {submission_score(submission, 'complete')}")
     subtasks = submission.get("subtasks") or []
     if subtasks:
+        def value_at(key: str, index: int) -> Any:
+            values = submission.get(key)
+            return values[index] if isinstance(values, list) and index < len(values) else None
+
         print("\nSubtasks:")
         for index, subtask in enumerate(subtasks):
             metric = subtask.get("metricName") or "metric"
             max_score = subtask.get("maximumScore") or "?"
-            partial_score = (
-                submission.get("partialSubtaskScores") or [None] * len(subtasks)
-            )[index]
-            partial_metric = (
-                submission.get("partialSubtaskMetricValues") or [None] * len(subtasks)
-            )[index]
+            partial_score = value_at("partialSubtaskScores", index)
+            partial_metric = value_at("partialSubtaskMetricValues", index)
             line = f"  #{subtask.get('id')} partial {partial_score}/{max_score}"
             if partial_metric is not None:
                 line += f" | {metric}: {partial_metric}"
             if submission.get("completeTaskScore") is not None:
-                complete_scores = submission.get("completeSubtaskScores") or [
-                    None
-                ] * len(subtasks)
-                complete_metrics = submission.get("completeSubtaskMetricValues") or [
-                    None
-                ] * len(subtasks)
-                line += f" | complete {complete_scores[index]}/{max_score}"
-                if complete_metrics[index] is not None:
-                    line += f" | {metric}: {complete_metrics[index]}"
+                complete_score = value_at("completeSubtaskScores", index)
+                complete_metric = value_at("completeSubtaskMetricValues", index)
+                line += f" | complete {complete_score}/{max_score}"
+                if complete_metric is not None:
+                    line += f" | {metric}: {complete_metric}"
             print(line)
 
 def poll_submission_feedback(
@@ -372,7 +385,7 @@ def poll_submission_feedback(
         if submission.get("state") != "pending":
             return submission
         if time.time() >= deadline:
-            raise RuntimeError("Timed out waiting for submission feedback")
+            raise SubmissionWaitTimeout("Timed out waiting for submission feedback")
         print("Waiting for feedback...", flush=True)
         time.sleep(interval)
 
@@ -398,6 +411,7 @@ def cmd_submit(
     source_path: str | None,
     note: str,
     wait: bool,
+    wait_timeout: int = 180,
 ) -> int:
     try:
         submission = create_submission(
@@ -407,27 +421,57 @@ def cmd_submit(
         print(f"Error: {e}")
         return 1
 
-    submission_id = submission.get("submissionID") or submission.get("submissionId")
+    created_submission_id = _submission_id(submission)
     index = submission.get("submissionConsumptionIndex")
-    print(f"Submission ID: {submission_id}")
+    print(f"Submission ID: {created_submission_id}")
     if index is not None:
         print(f"Submission Count: {index}")
 
-    if wait and submission_id:
-        try:
-            feedback = poll_submission_feedback(
-                cookies,
-                bearer,
-                submission_id,
-                org=org,
-                comp=comp,
-                task_id=task_id,
-            )
-        except RuntimeError as e:
-            print(f"Error: {e}")
-            return 1
-        print()
-        print_submission_details(feedback)
+    if wait and created_submission_id:
+        return cmd_wait_submission(
+            cookies,
+            bearer,
+            created_submission_id,
+            org=org,
+            comp=comp,
+            task_id=task_id,
+            timeout=wait_timeout,
+        )
+    return 0
+
+
+def cmd_wait_submission(
+    cookies: tuple[str, str],
+    bearer: str,
+    submission_id: str,
+    *,
+    org: str | None = None,
+    comp: str | None = None,
+    task_id: str | None = None,
+    timeout: int = 180,
+) -> int:
+    try:
+        feedback = poll_submission_feedback(
+            cookies,
+            bearer,
+            submission_id,
+            org=org,
+            comp=comp,
+            task_id=task_id,
+            timeout=timeout,
+        )
+    except SubmissionWaitTimeout as e:
+        print(f"Error: {e}")
+        print(f"Hint: retry with `naij submission {submission_id} --wait`.")
+        return 2
+    except KeyboardInterrupt:
+        print("\nWaiting interrupted; the remote submission was not cancelled.")
+        return 130
+    except RuntimeError as e:
+        print(f"Error: {e}")
+        return 1
+    print()
+    print_submission_details(feedback)
     return 0
 
 def cmd_submissions(
@@ -477,6 +521,8 @@ def cmd_submission(
     org: str | None = None,
     comp: str | None = None,
     task_id: str | None = None,
+    wait: bool = False,
+    wait_timeout: int = 180,
 ) -> int:
     try:
         submission_id = resolve_submission_id(
@@ -487,13 +533,18 @@ def cmd_submission(
             comp=comp,
             task_id=task_id,
         )
+        if wait:
+            return cmd_wait_submission(
+                cookies,
+                bearer,
+                submission_id,
+                org=org,
+                comp=comp,
+                task_id=task_id,
+                timeout=wait_timeout,
+            )
         submission = load_submission(
-            submission_id,
-            cookies,
-            bearer,
-            org=org,
-            comp=comp,
-            task_id=task_id,
+            submission_id, cookies, bearer, org=org, comp=comp, task_id=task_id
         )
     except RuntimeError as e:
         print(f"Error: {e}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,6 +109,13 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(slash.source, "source.py")
         self.assertEqual(slash.note, "note")
         self.assertTrue(slash.wait)
+        self.assertEqual(slash.wait_timeout, 180)
+
+        existing = parser.parse_args(
+            ["submission", "submission-id", "--wait", "--wait-timeout", "45"]
+        )
+        self.assertTrue(existing.wait)
+        self.assertEqual(existing.wait_timeout, 45)
 
     def test_download_and_submission_list_short_flags(self) -> None:
         parser = cli.build_parser()
@@ -306,6 +313,30 @@ class ContextDispatchTests(unittest.TestCase):
                             result = cli.main(["ls"])
                 self.assertEqual(result, 23)
                 command.assert_called_once()
+
+    def test_submission_wait_uses_selected_id_and_timeout(self) -> None:
+        auth = ({}, ("", ""), "token")
+        context = {
+            "contest": {"org": "o", "comp": "c"},
+            "task": {"id": "1"},
+            "submission": {"id": "selected-id"},
+        }
+        with patch.object(cli, "require_auth", return_value=auth), patch.object(
+            cli, "load_context", return_value=context
+        ), patch.object(cli, "cmd_submission", return_value=0) as command:
+            result = cli.main(["submission", "--wait", "--wait-timeout", "45"])
+
+        self.assertEqual(result, 0)
+        command.assert_called_once_with(
+            ("", ""),
+            "token",
+            "selected-id",
+            org="o",
+            comp="c",
+            task_id="1",
+            wait=True,
+            wait_timeout=45,
+        )
 
     def test_show_dispatches_submission_task_and_contest_levels(self) -> None:
         auth = ({}, ("", ""), "token")

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -7,6 +7,8 @@ import sys
 import tempfile
 import unittest
 from unittest.mock import patch
+import contextlib
+import io
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -225,6 +227,54 @@ class SubmissionTests(unittest.TestCase):
             },
         )
 
+    def test_submission_list_uses_nested_pagination_metadata(self) -> None:
+        pages: list[int] = []
+
+        def request(**kwargs: object) -> tuple[int, str, dict[str, str]]:
+            page = kwargs["params"]["page"]  # type: ignore[index]
+            pages.append(page)
+            return 200, json.dumps(
+                {
+                    "partialSubmissions": {
+                        "data": [{"id": f"p{page}"}],
+                        "lastPage": 2,
+                    }
+                }
+            ), {}
+
+        with patch.object(submissions, "api_request_text", side_effect=request):
+            items, last_page = submissions.load_submissions(
+                ("", ""),
+                "token",
+                "org",
+                "contest",
+                "7",
+                author=None,
+                page=None,
+                page_size=10,
+                mode="partial",
+            )
+
+        self.assertEqual(items, [{"id": "p1"}, {"id": "p2"}])
+        self.assertEqual(last_page, 2)
+        self.assertEqual(pages, [1, 2])
+
+    def test_short_subtask_arrays_render_missing_values(self) -> None:
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            submissions.print_submission_details(
+                {
+                    "subtasks": [{"id": 1}, {"id": 2}],
+                    "partialSubtaskScores": [42],
+                    "partialSubtaskMetricValues": [0.5],
+                    "completeTaskScore": 42,
+                    "completeSubtaskScores": [42],
+                    "completeSubtaskMetricValues": [0.5],
+                }
+            )
+
+        self.assertIn("#2 partial None/? | complete None/?", output.getvalue())
+
     def test_polling_returns_first_non_pending_feedback(self) -> None:
         pending = {"id": "one", "state": "pending"}
         complete = {"id": "one", "state": "complete"}
@@ -261,6 +311,50 @@ class SubmissionTests(unittest.TestCase):
             )
         self.assertEqual(result, 1)
         self.assertIn("missing", output.call_args.args[0])
+
+    def test_submit_wait_accepts_canonical_id(self) -> None:
+        feedback = {"id": "canonical-123", "state": "complete"}
+        with (
+            patch.object(
+                submissions, "create_submission", return_value={"id": "canonical-123"}
+            ),
+            patch.object(
+                submissions, "poll_submission_feedback", return_value=feedback
+            ) as poll,
+            patch.object(submissions, "print_submission_details"),
+        ):
+            result = submissions.cmd_submit(
+                ("", ""),
+                "token",
+                "org",
+                "contest",
+                "7",
+                "answer.csv",
+                None,
+                "",
+                True,
+            )
+
+        self.assertEqual(result, 0)
+        poll.assert_called_once()
+        self.assertEqual(poll.call_args.args[2], "canonical-123")
+
+    def test_existing_submission_wait_timeout_and_interrupt_have_distinct_results(self) -> None:
+        with patch.object(
+            submissions,
+            "poll_submission_feedback",
+            side_effect=submissions.SubmissionWaitTimeout("timed out"),
+        ):
+            self.assertEqual(
+                submissions.cmd_wait_submission(("", ""), "token", "id"), 2
+            )
+
+        with patch.object(
+            submissions, "poll_submission_feedback", side_effect=KeyboardInterrupt
+        ):
+            self.assertEqual(
+                submissions.cmd_wait_submission(("", ""), "token", "id"), 130
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- accept canonical submission IDs throughout submit-and-wait
- use nested pagination metadata and tolerate partial subtask arrays
- allow configurable waiting on existing or newly created submissions
- return distinct timeout and interrupt statuses with retry guidance

## Tests
- `python3 -m unittest tests.test_submissions tests.test_cli -v` (33 passed)
- `python3 -m unittest discover -s tests -v` (235 passed; 60 skipped; release test could not import because optional aiohttp is absent locally)
- `git diff --check`

Closes #17
Closes #18
Closes #19
Closes #53