### PR TITLE
Harden Play manager lifecycle and failure recovery

### DIFF
--- a/src/nitro_ai_judge_cli/manager/backend.py
+++ b/src/nitro_ai_judge_cli/manager/backend.py
@@ -591,10 +591,14 @@ class DockerBackend:
             "container": "",
             "was_running": False,
             "copied_workspace": False,
+            "created_workspace": False,
+            "created_secret": False,
+            "created_config": False,
             "project": "",
         }
         if not adoption or not adoption.get("verified"):
             await self._create_volume(names["workspace"], workspace_labels)
+            context["created_workspace"] = True
             return context
         manifest = adoption.get("manifest") or {}
         container = str(manifest.get("container_id") or "")
@@ -612,6 +616,7 @@ class DockerBackend:
             )
             if workspace == names["workspace"]:
                 await self._create_volume(workspace, workspace_labels)
+                context["created_workspace"] = True
             elif workspace != self._adopted_workspace(adoption):
                 raise WireError(
                     ErrorType.OWNERSHIP_MISMATCH.value,
@@ -656,53 +661,60 @@ class DockerBackend:
                 "project": expected_project,
             }
         )
-        await progress("preparing", "Stopping verified legacy environment for lazy cutover")
-        if context["was_running"]:
-            await self.run(["docker", "stop", container], timeout=90)
-        legacy_volume = self._adopted_workspace(adoption)
-        if legacy_volume:
-            if not await self._volume_details(legacy_volume):
-                raise WireError(
-                    ErrorType.NOT_FOUND.value,
-                    f"Verified legacy workspace volume is missing: {legacy_volume}",
-                    stage="preparing",
-                    status=409,
-                )
-            context["workspace"] = legacy_volume
-            return context
-        await progress("preparing", "Copying container-layer workspace into a private volume")
-        await self._create_volume(names["workspace"], workspace_labels)
-        temporary = f"{names['project']}-workspace-migration"
         try:
-            await self.run(
-                [
-                    "docker",
-                    "create",
-                    "--name",
-                    temporary,
-                    "-v",
-                    f"{names['workspace']}:/home/jovyan",
-                    "--entrypoint",
-                    "/bin/true",
-                    self.manager_image,
-                ],
-                timeout=60,
-            )
-            await self.run(["docker", "start", "--attach", temporary], timeout=60)
-            await self.run(
-                [
-                    "docker",
-                    "cp",
-                    "--archive",
-                    f"{container}:/home/jovyan/.",
-                    f"{temporary}:/home/jovyan",
-                ],
-                timeout=600,
-            )
-        finally:
-            await self.run(["docker", "rm", "-f", temporary], check=False, timeout=60)
-        context["copied_workspace"] = True
-        return context
+            await progress("preparing", "Stopping verified legacy environment for lazy cutover")
+            if context["was_running"]:
+                await self.run(["docker", "stop", container], timeout=90)
+            legacy_volume = self._adopted_workspace(adoption)
+            if legacy_volume:
+                if not await self._volume_details(legacy_volume):
+                    raise WireError(
+                        ErrorType.NOT_FOUND.value,
+                        f"Verified legacy workspace volume is missing: {legacy_volume}",
+                        stage="preparing",
+                        status=409,
+                    )
+                context["workspace"] = legacy_volume
+                return context
+            await progress("preparing", "Copying container-layer workspace into a private volume")
+            await self._create_volume(names["workspace"], workspace_labels)
+            context["created_workspace"] = True
+            temporary = f"{names['project']}-workspace-migration"
+            try:
+                await self.run(
+                    [
+                        "docker",
+                        "create",
+                        "--name",
+                        temporary,
+                        "-v",
+                        f"{names['workspace']}:/home/jovyan",
+                        "--entrypoint",
+                        "/bin/true",
+                        self.manager_image,
+                    ],
+                    timeout=60,
+                )
+                await self.run(["docker", "start", "--attach", temporary], timeout=60)
+                await self.run(
+                    [
+                        "docker",
+                        "cp",
+                        "--archive",
+                        f"{container}:/home/jovyan/.",
+                        f"{temporary}:/home/jovyan",
+                    ],
+                    timeout=600,
+                )
+            finally:
+                await asyncio.shield(
+                    self.run(["docker", "rm", "-f", temporary], check=False, timeout=60)
+                )
+            context["copied_workspace"] = True
+            return context
+        except BaseException:
+            await asyncio.shield(self._rollback_legacy(org, competition, context))
+            raise
 
     async def _finish_legacy(self, context: dict[str, Any]) -> None:
         container = str(context.get("container") or "")
@@ -725,24 +737,25 @@ class DockerBackend:
     async def _rollback_legacy(
         self, org: str, competition: str, context: dict[str, Any]
     ) -> None:
-        if not context.get("container"):
-            return
-        await self.run(
-            self.compose_command(org, competition, "down", "--remove-orphans"),
-            check=False,
-            timeout=180,
-        )
         names = self.names(org, competition)
         workspace = str(context["workspace"])
-        await self._remove_owned_volume(
-            names["secret"],
-            self.labels(org, competition, "secret", workspace=workspace),
-        )
-        await self._remove_owned_volume(
-            names["config"],
-            self.labels(org, competition, "jupyter-config", workspace=workspace),
-        )
-        if context.get("copied_workspace"):
+        if context.get("container"):
+            await self.run(
+                self.compose_command(org, competition, "down", "--remove-orphans"),
+                check=False,
+                timeout=180,
+            )
+        if context.get("created_secret"):
+            await self._remove_owned_volume(
+                names["secret"],
+                self.labels(org, competition, "secret", workspace=workspace),
+            )
+        if context.get("created_config"):
+            await self._remove_owned_volume(
+                names["config"],
+                self.labels(org, competition, "jupyter-config", workspace=workspace),
+            )
+        if context.get("created_workspace"):
             await self._remove_owned_volume(
                 names["workspace"],
                 self.labels(
@@ -752,7 +765,7 @@ class DockerBackend:
                     workspace=names["workspace"],
                 ),
             )
-        if context.get("was_running"):
+        if context.get("was_running") and context.get("container"):
             await self.run(
                 ["docker", "start", str(context["container"])], check=False, timeout=90
             )
@@ -1057,57 +1070,63 @@ class DockerBackend:
             legacy_context = await self._prepare_legacy(
                 org, competition, adoption, progress
             )
-            await self._write_volume_file(
-                names["secret"],
-                "session_whitelist_bypass_key",
-                (secrets.token_urlsafe(32) + "\n").encode(),
-                self.labels(
-                    org,
-                    competition,
-                    "secret",
-                    workspace=str(legacy_context["workspace"]),
-                ),
-            )
-            base_path = f"/nitro/competitions/{org}/{competition}/jupyter/"
-            jupyter_config = (
+            try:
+                legacy_context["created_secret"] = not bool(
+                    await self._volume_details(names["secret"])
+                )
+                await self._write_volume_file(
+                    names["secret"],
+                    "session_whitelist_bypass_key",
+                    (secrets.token_urlsafe(32) + "\n").encode(),
+                    self.labels(
+                        org,
+                        competition,
+                        "secret",
+                        workspace=str(legacy_context["workspace"]),
+                    ),
+                )
+                base_path = f"/nitro/competitions/{org}/{competition}/jupyter/"
+                jupyter_config = (
                 "c.ServerApp.base_url = " + repr(base_path) + "\n"
                 "c.ServerApp.allow_remote_access = True\n"
                 "c.ServerApp.trust_xheaders = True\n"
                 "c.ServerApp.allow_origin = ''\n"
                 "c.IdentityProvider.token = ''\n"
-            ).encode()
-            config_labels = self.labels(
-                org,
-                competition,
-                "jupyter-config",
-                workspace=str(legacy_context["workspace"]),
-            )
-            await self._write_volume_file(
-                names["config"],
-                "jupyter_server_config.py",
-                jupyter_config,
-                config_labels,
-                mode=0o644,
-            )
-            await self._write_volume_file(
-                names["config"], "migrated", b"", config_labels, mode=0o644
-            )
-            gpu_requested = (
+                ).encode()
+                config_labels = self.labels(
+                    org,
+                    competition,
+                    "jupyter-config",
+                    workspace=str(legacy_context["workspace"]),
+                )
+                legacy_context["created_config"] = not bool(
+                    await self._volume_details(names["config"])
+                )
+                await self._write_volume_file(
+                    names["config"],
+                    "jupyter_server_config.py",
+                    jupyter_config,
+                    config_labels,
+                    mode=0o644,
+                )
+                await self._write_volume_file(
+                    names["config"], "migrated", b"", config_labels, mode=0o644
+                )
+                gpu_requested = (
                 "required" if options.get("gpu") is True else "disabled" if options.get("gpu") is False else "auto"
-            )
-            assert resolved_images is not None
-            images = resolved_images
-            gpu = await self._gpu_enabled(images[0], gpu_requested)
-            compose = self._compose(
-                org,
-                competition,
-                gpu=gpu,
-                pull_policy="never",
-                workspace_name=str(legacy_context["workspace"]),
-                images=images,
-            )
-            self._atomic_compose(compose_path, compose)
-            try:
+                )
+                assert resolved_images is not None
+                images = resolved_images
+                gpu = await self._gpu_enabled(images[0], gpu_requested)
+                compose = self._compose(
+                    org,
+                    competition,
+                    gpu=gpu,
+                    pull_policy="never",
+                    workspace_name=str(legacy_context["workspace"]),
+                    images=images,
+                )
+                self._atomic_compose(compose_path, compose)
                 await progress("applying", "Starting competition services")
                 command = self.compose_command(org, competition, "up", "-d", "--remove-orphans")
                 if action == "recreate":
@@ -1118,8 +1137,10 @@ class DockerBackend:
                     org, competition, int(options.get("wait_timeout") or 120), progress
                 )
                 await self._finish_legacy(legacy_context)
-            except Exception:
-                await self._rollback_legacy(org, competition, legacy_context)
+            except BaseException:
+                await asyncio.shield(
+                    self._rollback_legacy(org, competition, legacy_context)
+                )
                 raise
             snapshot = await self.inspect_competition(org, competition)
             snapshot["workspace"] = legacy_context["workspace"]

--- a/src/nitro_ai_judge_cli/play_manager_client.py
+++ b/src/nitro_ai_judge_cli/play_manager_client.py
@@ -220,6 +220,22 @@ class ManagerClient:
                             "Unexpected response from Play manager log stream"
                         ) from exc
                     yield line + "\n"
+        except urllib.error.HTTPError as exc:
+            try:
+                parsed = json.loads(exc.read(65536) or b"{}")
+            except (UnicodeDecodeError, json.JSONDecodeError) as parse_error:
+                raise ManagerConnectionError(
+                    f"Unexpected response from Play manager (HTTP {exc.code})"
+                ) from parse_error
+            error = parsed.get("error") if isinstance(parsed, dict) else None
+            error = error if isinstance(error, dict) else {}
+            raise WireError(
+                str(error.get("type") or ErrorType.OPERATION_FAILED.value),
+                str(error.get("message") or f"Play manager returned HTTP {exc.code}"),
+                str(error.get("stage")) if error.get("stage") else None,
+                tuple(str(item) for item in error.get("logs", [])[-40:]),
+                exc.code,
+            ) from exc
         except (OSError, urllib.error.URLError) as exc:
             raise ManagerConnectionError("Play log stream disconnected") from exc
 

--- a/src/nitro_ai_judge_cli/play_manager_lifecycle.py
+++ b/src/nitro_ai_judge_cli/play_manager_lifecycle.py
@@ -42,7 +42,11 @@ class DockerEndpoint:
 
 
 def run_process(
-    command: list[str], *, check: bool = True, input_text: str | None = None
+    command: list[str],
+    *,
+    check: bool = True,
+    input_text: str | None = None,
+    timeout: float = 30,
 ) -> subprocess.CompletedProcess[str]:
     try:
         result = subprocess.run(
@@ -52,9 +56,15 @@ def run_process(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             check=False,
+            timeout=timeout,
         )
     except FileNotFoundError as exc:
         raise RuntimeError("Docker is not installed or not on PATH") from exc
+    except subprocess.TimeoutExpired as exc:
+        operation = " ".join(command[:3])
+        raise RuntimeError(
+            f"Docker operation timed out after {timeout:g} seconds: {operation}"
+        ) from exc
     if check and result.returncode:
         details = (result.stderr or result.stdout or "").strip()
         raise RuntimeError(details or f"{command[0]} exited with {result.returncode}")
@@ -140,6 +150,11 @@ def validate_manager_exposure(
     tls_key: str | None,
     public_url: str | None,
 ) -> None:
+    if bool(tls_cert) != bool(tls_key):
+        raise ValueError("--tls-cert and --tls-key must be supplied together")
+    for path, label in ((tls_cert, "TLS certificate"), (tls_key, "TLS key")):
+        if path and not os.path.isfile(path):
+            raise ValueError(f"{label} does not exist: {path}")
     loopback = bind in {"127.0.0.1", "::1", "localhost"}
     if loopback:
         return
@@ -150,9 +165,6 @@ def validate_manager_exposure(
     parsed = urlsplit(public_url)
     if parsed.scheme != "https" or not parsed.netloc:
         raise ValueError("--public-url must be an absolute HTTPS URL")
-    for path, label in ((tls_cert, "TLS certificate"), (tls_key, "TLS key")):
-        if not os.path.isfile(path):
-            raise ValueError(f"{label} does not exist: {path}")
 
 
 def generate_manager_compose(
@@ -313,6 +325,7 @@ def install_manager(
     public_url: str | None = None,
     update: bool = False,
 ) -> dict[str, Any]:
+    bind = "127.0.0.1" if bind == "localhost" else bind
     validate_manager_exposure(
         bind, tls_cert=tls_cert, tls_key=tls_key, public_url=public_url
     )
@@ -333,12 +346,27 @@ def install_manager(
     host = "localhost" if bind in {"127.0.0.1", "::1"} else bind
     public_url = (public_url or f"{scheme}://{host}:{port}").rstrip("/")
     if _port_in_use(bind, port):
+        local_state = old_config is not None and os.path.isfile(paths["token"])
         try:
-            existing = ManagerClient(public_url).info()
+            probe = ManagerClient(public_url)
+            existing = probe.info()
             verify_manager_info(existing)
         except Exception as exc:
             raise RuntimeError(
                 f"Port {bind}:{port} is occupied by another service; choose a different --port"
+            ) from exc
+        if not local_state:
+            raise RuntimeError(
+                "A compatible Play manager is running on this port, but its local "
+                "configuration or API credential is missing; restore the original "
+                "NAIJ state directory or choose another --port"
+            )
+        try:
+            ManagerClient.from_state().competitions()
+        except Exception as exc:
+            raise RuntimeError(
+                "The running Play manager could not authenticate with the saved "
+                "local state; restore its API credential or choose another --port"
             ) from exc
         if not update:
             return existing
@@ -366,7 +394,7 @@ def install_manager(
     compose = generate_manager_compose(config, endpoint)
     image_present = run_process(["docker", "image", "inspect", image], check=False).returncode == 0
     if update or not image_present:
-        run_process(["docker", "pull", image])
+        run_process(["docker", "pull", image], timeout=1800)
     try:
         atomic_write(
             paths["config"],
@@ -376,7 +404,7 @@ def install_manager(
             paths["compose"],
             (json.dumps(compose, indent=2, sort_keys=True) + "\n").encode(),
         )
-        run_process(_compose_command("up", "-d", "--remove-orphans"))
+        run_process(_compose_command("up", "-d", "--remove-orphans"), timeout=300)
         info = _verify_manager()
         sync_manager_credentials(required=False)
         from .play_legacy import discover_legacy_environments
@@ -392,7 +420,11 @@ def install_manager(
                 (json.dumps(old_config, indent=2, sort_keys=True) + "\n").encode(),
             )
             atomic_write(paths["compose"], old_compose)
-            run_process(_compose_command("up", "-d", "--remove-orphans"), check=False)
+            run_process(
+                _compose_command("up", "-d", "--remove-orphans"),
+                check=False,
+                timeout=300,
+            )
         raise
 
 
@@ -426,7 +458,7 @@ def manager_compose_action(action: str) -> None:
         raise RuntimeError("Play manager is not installed")
     if action not in {"start", "stop", "restart"}:
         raise ValueError(f"Unsupported manager action: {action}")
-    run_process(_compose_command(action))
+    run_process(_compose_command(action), timeout=180)
     if action != "stop":
         _verify_manager()
 
@@ -434,7 +466,7 @@ def manager_compose_action(action: str) -> None:
 def uninstall_manager() -> None:
     if not load_manager_config():
         return
-    run_process(_compose_command("down", "--remove-orphans"))
+    run_process(_compose_command("down", "--remove-orphans"), timeout=180)
 
 
 def purge_manager_state(*, force: bool = False) -> None:
@@ -453,7 +485,7 @@ def purge_manager_state(*, force: bool = False) -> None:
             raise RuntimeError(
                 f"Refusing to remove volume {MANAGER_VOLUME}: ownership label is missing"
             )
-        run_process(["docker", "volume", "rm", MANAGER_VOLUME])
+        run_process(["docker", "volume", "rm", MANAGER_VOLUME], timeout=60)
 
 
 def normalized_credentials(value: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -250,6 +250,96 @@ class ManagerBackendSafetyTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(context["workspace"], "legacy")
 
+    async def test_missing_adopted_volume_restarts_running_legacy_container(self) -> None:
+        inspected = json.dumps(
+            [{
+                "Config": {"Labels": {
+                    "com.docker.compose.project": "legacy-project",
+                    "com.docker.compose.service": "jupyter-server",
+                }},
+                "State": {"Running": True},
+            }]
+        )
+
+        async def run(command, **_options):
+            if command[:2] == ["docker", "inspect"]:
+                return 0, inspected, ""
+            return 0, "", ""
+
+        self.backend.run = AsyncMock(side_effect=run)
+        self.backend._volume_details = AsyncMock(return_value=None)
+        adoption = {
+            "verified": True,
+            "manifest": {
+                "container_id": "legacy",
+                "project": "legacy-project",
+                "workspace_kind": "volume",
+                "workspace_volume": "missing",
+            },
+        }
+        with self.assertRaisesRegex(WireError, "workspace volume is missing"):
+            await self.backend._prepare_legacy(
+                "org", "contest", adoption, AsyncMock()
+            )
+        commands = [call.args[0] for call in self.backend.run.await_args_list]
+        self.assertIn(["docker", "stop", "legacy"], commands)
+        self.assertIn(["docker", "start", "legacy"], commands)
+
+    async def test_copy_failure_removes_new_workspace_and_restarts_legacy(self) -> None:
+        inspected = json.dumps(
+            [{
+                "Config": {"Labels": {
+                    "com.docker.compose.project": "legacy-project",
+                    "com.docker.compose.service": "jupyter-server",
+                }},
+                "State": {"Running": True},
+            }]
+        )
+
+        async def run(command, **_options):
+            if command[:2] == ["docker", "inspect"]:
+                return 0, inspected, ""
+            if command[:2] == ["docker", "create"]:
+                raise RuntimeError("create failed")
+            return 0, "", ""
+
+        self.backend.run = AsyncMock(side_effect=run)
+        self.backend._create_volume = AsyncMock()
+        self.backend._remove_owned_volume = AsyncMock()
+        adoption = {
+            "verified": True,
+            "manifest": {"container_id": "legacy", "project": "legacy-project"},
+        }
+        with self.assertRaisesRegex(RuntimeError, "create failed"):
+            await self.backend._prepare_legacy(
+                "org", "contest", adoption, AsyncMock()
+            )
+        self.backend._remove_owned_volume.assert_awaited_once()
+        commands = [call.args[0] for call in self.backend.run.await_args_list]
+        self.assertIn(["docker", "start", "legacy"], commands)
+
+    async def test_cancellation_after_legacy_preparation_runs_rollback(self) -> None:
+        context = {
+            "workspace": "workspace",
+            "container": "legacy",
+            "was_running": True,
+            "created_workspace": False,
+            "created_secret": False,
+            "created_config": False,
+        }
+        self.backend._pull = AsyncMock(return_value=("notebook", "proxy"))
+        self.backend._prepare_legacy = AsyncMock(return_value=context)
+        self.backend._volume_details = AsyncMock(return_value=None)
+        self.backend._write_volume_file = AsyncMock(side_effect=asyncio.CancelledError)
+        self.backend._rollback_legacy = AsyncMock()
+        with self.assertRaises(asyncio.CancelledError):
+            await self.backend.perform(
+                "org", "contest", "play", {"pull": "never"}, AsyncMock()
+            )
+        self.backend._rollback_legacy.assert_awaited_once_with(
+            "org", "contest", context
+        )
+
     async def test_ready_is_workspace_only_and_stopped_requires_containers(self) -> None:
         images = {
             "notebook": {"name": "notebook", "state": "ready"},

--- a/tests/test_play.py
+++ b/tests/test_play.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import subprocess
 import tempfile
 import unittest
 from contextlib import redirect_stdout
@@ -568,6 +569,71 @@ class ManagerConfigurationTests(unittest.TestCase):
             "127.0.0.1", tls_cert=None, tls_key=None, public_url=None
         )
 
+    def test_tls_certificate_and_key_are_required_as_a_pair(self) -> None:
+        for cert, key in (("/cert.pem", None), (None, "/key.pem")):
+            with self.subTest(cert=cert, key=key), self.assertRaisesRegex(
+                ValueError, "supplied together"
+            ):
+                validate_manager_exposure(
+                    "127.0.0.1", tls_cert=cert, tls_key=key, public_url=None
+                )
+
+    def test_run_process_passes_timeout_and_renders_expiry(self) -> None:
+        with patch.object(
+            play_manager_lifecycle.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(["docker", "info"], 7),
+        ) as run:
+            with self.assertRaisesRegex(RuntimeError, "timed out after 7 seconds"):
+                play_manager_lifecycle.run_process(["docker", "info"], timeout=7)
+        self.assertEqual(run.call_args.kwargs["timeout"], 7)
+
+    def test_occupied_compatible_port_requires_local_authenticated_state(self) -> None:
+        endpoint = DockerEndpoint(
+            "default", "unix:///run/docker.sock", "/run/docker.sock", "linux"
+        )
+        info = {
+            "identity": "naij-play-manager",
+            "api_version": 1,
+            "minimum_cli_version": "0.0.0",
+        }
+        with (
+            patch.object(
+                play_manager_lifecycle, "resolve_docker_endpoint", return_value=endpoint
+            ),
+            patch.object(play_manager_lifecycle, "_port_in_use", return_value=True),
+            patch.object(ManagerClient, "info", return_value=info),
+            self.assertRaisesRegex(RuntimeError, "local configuration or API credential"),
+        ):
+            play_manager_lifecycle.install_manager()
+
+    def test_install_normalizes_localhost_before_compose_generation(self) -> None:
+        endpoint = DockerEndpoint(
+            "default", "unix:///run/docker.sock", "/run/docker.sock", "linux"
+        )
+        process = SimpleNamespace(returncode=0, stdout="", stderr="")
+        with (
+            patch.object(
+                play_manager_lifecycle, "resolve_docker_endpoint", return_value=endpoint
+            ),
+            patch.object(play_manager_lifecycle, "_port_in_use", return_value=False),
+            patch.object(play_manager_lifecycle, "run_process", return_value=process),
+            patch.object(play_manager_lifecycle, "_verify_manager", return_value={}),
+            patch.object(play_manager_lifecycle, "sync_manager_credentials"),
+            patch(
+                "nitro_ai_judge_cli.play_legacy.discover_legacy_environments",
+                return_value=[],
+            ),
+        ):
+            play_manager_lifecycle.install_manager(bind="localhost")
+        config = play_manager_lifecycle.load_manager_config()
+        self.assertEqual(config["bind"], "127.0.0.1")
+        with open(play_manager_lifecycle.manager_paths()["compose"], encoding="utf-8") as stream:
+            compose = json.load(stream)
+        self.assertEqual(
+            compose["services"]["manager"]["ports"], ["127.0.0.1:51123:51123"]
+        )
+
     def test_update_restores_config_when_compose_write_fails(self) -> None:
         root = state.ensure_state_dir().play_manager
         os.makedirs(root)
@@ -658,6 +724,26 @@ class ManagerClientTests(unittest.TestCase):
                 )
         self.assertEqual(caught.exception.type, "competition_busy")
         self.assertEqual(caught.exception.status, 409)
+
+    def test_follow_logs_preserves_typed_http_error(self) -> None:
+        error = __import__("urllib.error", fromlist=["HTTPError"]).HTTPError(
+            "http://localhost", 401, "unauthorized", {}, io.BytesIO(
+                b'{"error":{"type":"authentication_required","message":"sign in again","stage":"validating","logs":["safe"]}}'
+            )
+        )
+        with patch("urllib.request.urlopen", side_effect=error):
+            with self.assertRaises(WireError) as caught:
+                list(ManagerClient("http://localhost", "token").follow_logs("org", "contest"))
+        self.assertEqual(caught.exception.status, 401)
+        self.assertEqual(caught.exception.type, "authentication_required")
+        self.assertEqual(caught.exception.stage, "validating")
+        self.assertEqual(caught.exception.logs, ("safe",))
+
+    def test_follow_logs_reports_network_disconnect_separately(self) -> None:
+        error = __import__("urllib.error", fromlist=["URLError"]).URLError("down")
+        with patch("urllib.request.urlopen", side_effect=error):
+            with self.assertRaisesRegex(Exception, "stream disconnected"):
+                list(ManagerClient("http://localhost", "token").follow_logs("org", "contest"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- restore verified legacy environments on preparation, apply, and cancellation failures
- require authenticated local state before reusing an occupied manager port
- normalize loopback binds and validate TLS certificate/key pairs early
- bound host Docker subprocesses with operation-specific timeouts
- preserve structured manager errors from followed log streams

## Verification

- `uv run --extra manager python -m unittest discover -s tests -v` (241 passed, 2 skipped)
- `git diff --check`

Closes #12
Closes #25
Closes #26
Closes #27
Closes #31
Closes #32