### PR TITLE
feat: add CLI logout, version output, and password stdin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,11 @@ jobs:
           cmp /tmp/naij-help /tmp/nitro-cli-help
           cmp /tmp/naij-help /tmp/naij-module-help
           test "$(cat /tmp/nitro-cli-warning)" = 'warning: `nitro-cli` is deprecated; use `naij`. It will be removed in 4.0.0.'
+          VERSION="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          test "$(naij --version)" = "naij ${VERSION}"
+          test "$(python -m nitro_ai_judge_cli --version)" = "naij ${VERSION}"
+          test "$(nitro-cli --version 2>/tmp/nitro-cli-version-warning)" = "naij ${VERSION}"
+          test "$(cat /tmp/nitro-cli-version-warning)" = 'warning: `nitro-cli` is deprecated; use `naij`. It will be removed in 4.0.0.'
       - uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions

--- a/README.md
+++ b/README.md
@@ -63,9 +63,15 @@ python3 -m pip install -e .
 ```bash
 naij login
 naij login --username MihneaStoica
+secret-tool lookup service naij | naij login --username USER --password-stdin
+naij logout
+naij --version
 ```
 
 Login posts to Nitro's `/api/auth/login` endpoint and stores the returned access and refresh tokens. Nitro AI Judge refreshes an expired access token when possible and asks you to log in again when the saved refresh token is no longer valid.
+`--password-stdin` accepts one password line from a pipe and refuses an interactive
+terminal. `naij logout` removes only CLI credentials; Play manager credentials,
+context, cache, history, and workspaces remain unchanged.
 
 ## Full-screen TUI
 

--- a/src/nitro_ai_judge_cli/api.py
+++ b/src/nitro_ai_judge_cli/api.py
@@ -544,7 +544,10 @@ def cmd_login(username: str | None, password: str | None) -> int:
         print(f"Login OK | user={state.get('username')} | role={state.get('role')}")
         return 0
 
-    print(f"Login failed: {result.get('error')}")
+    error = str(result.get("error"))
+    if password:
+        error = error.replace(password, "[redacted]")
+    print(f"Login failed: {error}")
     return 1
 
 

--- a/src/nitro_ai_judge_cli/cli.py
+++ b/src/nitro_ai_judge_cli/cli.py
@@ -6,6 +6,7 @@ import argparse
 import sys
 from typing import Any
 
+from . import __version__
 from .api import cmd_login, configure_runtime, get_auth, require_auth
 from .completion import candidates as completion_candidates, script as completion_script
 from .config import (
@@ -27,6 +28,7 @@ from .play import PLAY_ACTIONS, add_play_parser, cmd_play, normalize_play_argv
 from .shell import run_shell
 from .state import (
     CredentialsError,
+    clear_credentials,
     clear_context,
     configure_state_dir,
     load_context,
@@ -252,6 +254,9 @@ def build_parser() -> argparse.ArgumentParser:
 """,
     )
     parser.add_argument(
+        "-V", "--version", action="version", version=f"%(prog)s {__version__}"
+    )
+    parser.add_argument(
         "--api-url",
         help="Backend API base URL (CLI, NAIJ_API_BASE_URL, NITRO_API_BASE_URL, PROXY_URL, then default)",
     )
@@ -268,6 +273,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     login = sub.add_parser("login", help="Login to Nitro Judge")
     login.add_argument("--username")
+    login.add_argument(
+        "--password-stdin",
+        action="store_true",
+        help="Read one password line from non-interactive stdin",
+    )
+
+    sub.add_parser("logout", help="Remove saved CLI credentials")
 
     sub.add_parser("tui", help="Open the full-screen contest cockpit")
 
@@ -523,7 +535,19 @@ def main(argv: list[str] | None = None) -> int:
     if not args.cmd:
         return run_shell(lambda words: main(words))
     if args.cmd == "login":
-        result = cmd_login(args.username, None)
+        password = None
+        if args.password_stdin:
+            if not args.username:
+                print("Error: --username is required with --password-stdin.", file=sys.stderr)
+                return 2
+            if sys.stdin.isatty():
+                print("Error: --password-stdin requires piped input.", file=sys.stderr)
+                return 2
+            password = sys.stdin.readline().rstrip("\r\n")
+            if not password:
+                print("Error: --password-stdin received an empty password.", file=sys.stderr)
+                return 2
+        result = cmd_login(args.username, password)
         if result == 0:
             from .play_manager_lifecycle import (
                 load_manager_config,
@@ -540,6 +564,18 @@ def main(argv: list[str] | None = None) -> int:
                         file=sys.stderr,
                     )
         return result
+    if args.cmd == "logout":
+        try:
+            removed = clear_credentials()
+        except CredentialsError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+        print("Logged out." if removed else "Already logged out.")
+        print(
+            "Play manager credentials were not changed; run `naij play manager open` "
+            "and choose Disconnect Nitro to remove them."
+        )
+        return 0
     if args.cmd == "tui":
         from .tui import run_tui
 

--- a/src/nitro_ai_judge_cli/completion.py
+++ b/src/nitro_ai_judge_cli/completion.py
@@ -10,7 +10,7 @@ from .state import load_context, selected_contest, selected_submission, selected
 
 
 COMMANDS = (
-    "login", "tui", "contests", "tasks", "task", "download-data", "play", "submit",
+    "login", "logout", "tui", "contests", "tasks", "task", "download-data", "play", "submit",
     "submissions", "submission", "set-final", "unset-final", "use", "ls",
     "show", "completion",
 )
@@ -18,7 +18,7 @@ SHELL_COMMANDS = (
     "help", "cd", "pwd", "l", "h", "?", "q", "quit", "exit", "..",
     "back", "unselect",
 )
-GLOBAL_OPTIONS = ("--api-url", "--submission-proxy", "--state-dir", "--help")
+GLOBAL_OPTIONS = ("--api-url", "--submission-proxy", "--state-dir", "-V", "--version", "--help")
 PLAY_ACTIONS = (
     "play", "pull", "start", "stop", "restart", "recreate",
     "delete-container", "delete-image", "delete-workspace", "logs", "status", "cancel", "open", "manager",
@@ -28,7 +28,7 @@ MANAGER_ACTIONS = (
     "uninstall", "purge", "sync-credentials",
 )
 OPTION_GROUPS = {
-    "login": (("--username",), ("--help",)),
+    "login": (("--username",), ("--password-stdin",), ("--help",)),
     "tui": (("--help",),),
     "contests": (
         ("--page",), ("--page-size",), ("--all-pages",), ("--all",),

--- a/src/nitro_ai_judge_cli/state.py
+++ b/src/nitro_ai_judge_cli/state.py
@@ -204,6 +204,21 @@ def save_state(value: dict[str, Any]) -> None:
     _write_json(paths.credentials, value)
 
 
+def clear_credentials() -> bool:
+    """Remove only the credential file for the resolved state root."""
+    path = resolve_state_paths().credentials
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise CredentialsError(
+            f"could not remove saved credentials in {path} ({exc})"
+        ) from exc
+    _fsync_directory(os.path.dirname(path))
+    return True
+
+
 def load_context() -> dict[str, Any]:
     path = resolve_state_paths().context
     if not os.path.exists(path):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -318,6 +318,25 @@ class AuthenticationTests(unittest.TestCase):
             self.assertEqual(api.cmd_login("alice", "wrong"), 1)
         self.assertEqual(output.getvalue().strip(), "Login failed: denied")
 
+    def test_cmd_login_redacts_password_from_failure_output(self) -> None:
+        output = io.StringIO()
+        with (
+            patch.object(
+                api,
+                "do_login",
+                return_value={
+                    "success": False,
+                    "tokens": None,
+                    "error": "rejected visible-secret",
+                },
+            ),
+            contextlib.redirect_stdout(output),
+        ):
+            self.assertEqual(api.cmd_login("alice", "visible-secret"), 1)
+
+        self.assertNotIn("visible-secret", output.getvalue())
+        self.assertIn("[redacted]", output.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ from unittest.mock import patch
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
-from nitro_ai_judge_cli import cli, state  # noqa: E402
+from nitro_ai_judge_cli import __version__, cli, state  # noqa: E402
 
 
 def invoke(function, argv: list[str]) -> tuple[int, str, str]:
@@ -29,6 +29,17 @@ def invoke(function, argv: list[str]) -> tuple[int, str, str]:
 
 
 class EntrypointTests(unittest.TestCase):
+    def test_version_entrypoints_report_installed_version_without_runtime_setup(self) -> None:
+        with patch.object(cli, "configure_runtime", side_effect=AssertionError("runtime")):
+            canonical = invoke(cli.main, ["--version"])
+            short = invoke(cli.main, ["-V"])
+            legacy = invoke(cli.legacy_main, ["--version"])
+
+        self.assertEqual(canonical, (0, f"naij {__version__}\n", ""))
+        self.assertEqual(short, canonical)
+        self.assertEqual(legacy[:2], canonical[:2])
+        self.assertEqual(legacy[2], cli.LEGACY_WARNING + "\n")
+
     def test_legacy_help_has_canonical_output_and_exact_warning(self) -> None:
         canonical = invoke(cli.main, ["--help"])
         legacy = invoke(cli.legacy_main, ["--help"])
@@ -80,6 +91,102 @@ class EntrypointTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("usage: naij", result.stdout)
         self.assertNotIn("deprecated", result.stderr)
+
+    def test_python_module_reports_canonical_version(self) -> None:
+        environment = os.environ.copy()
+        environment["PYTHONPATH"] = str(ROOT / "src")
+        result = subprocess.run(
+            [sys.executable, "-m", "nitro_ai_judge_cli", "--version"],
+            cwd=ROOT,
+            env=environment,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, f"naij {__version__}\n")
+
+
+class CredentialCommandTests(unittest.TestCase):
+    def tearDown(self) -> None:
+        state.configure_state_dir(None)
+
+    def test_password_stdin_reads_one_line(self) -> None:
+        with (
+            patch.object(cli.sys, "stdin", io.StringIO("secret phrase\nignored\n")),
+            patch.object(cli, "cmd_login", return_value=1) as login,
+        ):
+            result = invoke(cli.main, ["login", "--username", "alice", "--password-stdin"])
+
+        self.assertEqual(result, (1, "", ""))
+        login.assert_called_once_with("alice", "secret phrase")
+
+    def test_password_stdin_rejects_empty_and_interactive_input(self) -> None:
+        with patch.object(cli.sys, "stdin", io.StringIO("secret\n")), patch.object(
+            cli, "cmd_login"
+        ) as login:
+            missing_username = invoke(cli.main, ["login", "--password-stdin"])
+        self.assertEqual(missing_username[0], 2)
+        self.assertIn("--username is required", missing_username[2])
+        login.assert_not_called()
+
+        with patch.object(cli.sys, "stdin", io.StringIO("")), patch.object(
+            cli, "cmd_login"
+        ) as login:
+            empty = invoke(
+                cli.main, ["login", "--username", "alice", "--password-stdin"]
+            )
+        self.assertEqual(empty[0], 2)
+        self.assertIn("empty password", empty[2])
+        login.assert_not_called()
+
+        terminal = io.StringIO("secret\n")
+        terminal.isatty = lambda: True  # type: ignore[method-assign]
+        with patch.object(cli.sys, "stdin", terminal), patch.object(
+            cli, "cmd_login"
+        ) as login:
+            interactive = invoke(
+                cli.main, ["login", "--username", "alice", "--password-stdin"]
+            )
+        self.assertEqual(interactive[0], 2)
+        self.assertIn("requires piped input", interactive[2])
+        login.assert_not_called()
+
+    def test_logout_removes_only_custom_root_credentials_and_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            state.configure_state_dir(str(root))
+            state.save_state({"access_token": "secret"})
+            state.save_context({"contest": {"org": "o", "comp": "c"}})
+            (root / "history").write_text("kept", encoding="utf-8")
+            (root / "play-manager").mkdir()
+            (root / "play-manager" / "manager.json").write_text("{}", encoding="utf-8")
+
+            first = invoke(cli.main, ["--state-dir", str(root), "logout"])
+            second = invoke(cli.main, ["--state-dir", str(root), "logout"])
+
+            self.assertEqual(first[0], 0)
+            self.assertIn("Logged out", first[1])
+            self.assertIn("Disconnect Nitro", first[1])
+            self.assertEqual(second[0], 0)
+            self.assertIn("Already logged out", second[1])
+            self.assertFalse((root / "state.json").exists())
+            self.assertTrue((root / "context.json").exists())
+            self.assertEqual((root / "history").read_text(encoding="utf-8"), "kept")
+            self.assertTrue((root / "play-manager" / "manager.json").exists())
+
+    def test_logout_reports_credential_removal_failure(self) -> None:
+        with patch.object(
+            cli,
+            "clear_credentials",
+            side_effect=state.CredentialsError("permission denied"),
+        ):
+            result = invoke(cli.main, ["logout"])
+
+        self.assertEqual(result[0], 1)
+        self.assertIn("permission denied", result[2])
 
 
 class ParserTests(unittest.TestCase):

--- a/tests/test_state_completion.py
+++ b/tests/test_state_completion.py
@@ -202,6 +202,16 @@ class StateTests(unittest.TestCase):
         self.assertEqual(target.read_bytes(), b"old")
         self.assertFalse(any(item.name.startswith(".naij-") for item in root.iterdir()))
 
+    def test_failed_credential_removal_preserves_credentials(self) -> None:
+        root = self.set_state_root()
+        state.save_state({"access_token": "secret"})
+
+        with patch.object(state.os, "unlink", side_effect=OSError("denied")):
+            with self.assertRaisesRegex(state.CredentialsError, "denied"):
+                state.clear_credentials()
+
+        self.assertTrue((root / "state.json").exists())
+
     def test_corrupt_credentials_raise_actionable_error_without_rewrite(self) -> None:
         root = self.set_state_root()
         root.mkdir()
@@ -459,6 +469,9 @@ class CompletionTests(unittest.TestCase):
         self.assertNotIn("-m", values)
         self.assertNotIn("--mode", values)
         self.assertEqual(completion.candidates(["login", "--username", ""], context), [])
+        self.assertIn("--password-stdin", completion.candidates(["login", ""], context))
+        self.assertEqual(completion.candidates(["lo"], context), ["login", "logout"])
+        self.assertEqual(completion.candidates(["--v"], context), ["--version"])
         self.assertNotIn(
             "always", completion.candidates(["play", "logs", "--pull", ""], context)
         )


### PR DESCRIPTION
Closes #49
Closes #50
Closes #55

Adds scoped CLI credential removal, standard installed-version flags, and secure non-interactive login through one stdin line. Completion, documentation, failure handling, direct tests, and built-wheel smoke coverage are included.

Verification: `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests` (240 passed, 2 skipped).