### PR TITLE
Bound server-driven pagination requests

### DIFF
--- a/src/nitro_ai_judge_cli/config.py
+++ b/src/nitro_ai_judge_cli/config.py
@@ -13,6 +13,7 @@ DEFAULT_API_BASE_URL = f"{BASE_URL}/api"
 TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
 DEFAULT_PAGE_SIZE = 20
 DEFAULT_SUBMISSION_PAGE_SIZE = 10
+MAX_PAGINATION_PAGES = 1_000
 TASK_FILE_CATEGORIES = {
     "statement": "Statement",
     "train_data": "Train data",

--- a/src/nitro_ai_judge_cli/contests.py
+++ b/src/nitro_ai_judge_cli/contests.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from html.parser import HTMLParser
 import json
 import os
@@ -13,11 +12,10 @@ import zipfile
 from typing import Any
 
 from .api import api_request_bytes, api_request_text, body_json, error_preview, int_payload, list_payload, parse_singlefetch, request, request_text
-from .config import BASE_URL, DEFAULT_PAGE_SIZE, TASK_FILE_CATEGORIES, DEFAULT_TASK_FILE_CATEGORIES, TASK_FILE_PAGE_LABELS
+from .config import BASE_URL, DEFAULT_PAGE_SIZE, TASK_FILE_CATEGORIES, DEFAULT_TASK_FILE_CATEGORIES, TASK_FILE_PAGE_LABELS, MAX_PAGINATION_PAGES
 from .state import update_cache
 from .ui import _start_spinner, _stop_spinner, format_datetime_ms
 
-COMPETITION_PAGE_WORKERS = 4
 ZIP_BOMB_MAX_FILES = 10_000
 ZIP_BOMB_MAX_UNCOMPRESSED_BYTES = 5 * 1024**3
 ZIP_BOMB_MAX_COMPRESSION_RATIO = 200
@@ -281,47 +279,31 @@ def load_competitions(
         cookies, bearer, page=1, page_size=page_size, featured=featured
     )
     all_competitions = list(competitions)
-    if last_page == 0:
-        previous_page = repr(competitions)
-        for next_page in range(2, 1001):
-            page_items, discovered_last_page = load_competitions_page(
-                cookies,
-                bearer,
-                page=next_page,
-                page_size=page_size,
-                featured=featured,
-            )
-            if not page_items or repr(page_items) == previous_page:
-                break
-            all_competitions.extend(page_items)
-            previous_page = repr(page_items)
-            if discovered_last_page and next_page >= discovered_last_page:
-                break
-        return all_competitions
-    if last_page <= 1:
+    if not competitions or last_page == 1:
         return all_competitions
 
-    page_results: dict[int, list[dict[str, Any]]] = {}
-    max_workers = min(COMPETITION_PAGE_WORKERS, last_page - 1)
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = {
-            executor.submit(
-                load_competitions_page,
-                cookies,
-                bearer,
-                page=next_page,
-                page_size=page_size,
-                featured=featured,
-            ): next_page
-            for next_page in range(2, last_page + 1)
-        }
-        for future in as_completed(futures):
-            next_page = futures[future]
-            page_items, _ = future.result()
-            page_results[next_page] = page_items
-
-    for next_page in range(2, last_page + 1):
-        all_competitions.extend(page_results.get(next_page, []))
+    page_limit = min(
+        max(last_page, 1) if last_page else MAX_PAGINATION_PAGES,
+        MAX_PAGINATION_PAGES,
+    )
+    seen_pages = {repr(competitions)}
+    for next_page in range(2, page_limit + 1):
+        page_items, discovered_last_page = load_competitions_page(
+            cookies,
+            bearer,
+            page=next_page,
+            page_size=page_size,
+            featured=featured,
+        )
+        signature = repr(page_items)
+        if not page_items or signature in seen_pages:
+            break
+        all_competitions.extend(page_items)
+        seen_pages.add(signature)
+        if discovered_last_page and next_page >= min(
+            discovered_last_page, MAX_PAGINATION_PAGES
+        ):
+            break
     return all_competitions
 
 def print_competitions(competitions: list[dict[str, Any]]) -> None:

--- a/src/nitro_ai_judge_cli/submissions.py
+++ b/src/nitro_ai_judge_cli/submissions.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from . import config
 from .api import api_request_text, body_json, build_multipart, error_preview, parse_singlefetch, request_text
-from .config import DEFAULT_SUBMISSION_PAGE_SIZE
+from .config import DEFAULT_SUBMISSION_PAGE_SIZE, MAX_PAGINATION_PAGES
 from .state import load_state, update_cache
 from .ui import format_datetime_ms
 
@@ -263,13 +263,22 @@ def load_submissions(
         if api_page is not None:
             items, last_page = api_page
             all_items = list(items)
-            for next_page in range(2, last_page + 1):
+            if not items:
+                return all_items, min(last_page, MAX_PAGINATION_PAGES)
+            seen_pages = {repr(items)}
+            for next_page in range(
+                2, min(last_page, MAX_PAGINATION_PAGES) + 1
+            ):
                 next_api_page = fetch_api_page(next_page)
                 if next_api_page is None:
                     break
                 page_items, _ = next_api_page
+                signature = repr(page_items)
+                if not page_items or signature in seen_pages:
+                    break
                 all_items.extend(page_items)
-            return all_items, last_page
+                seen_pages.add(signature)
+            return all_items, min(last_page, MAX_PAGINATION_PAGES)
 
     def fetch_page(target_page: int) -> tuple[list[dict[str, Any]], int]:
         status, body, _ = request_text(
@@ -301,10 +310,17 @@ def load_submissions(
 
     items, last_page = fetch_page(1)
     all_items = list(items)
-    for next_page in range(2, last_page + 1):
+    if not items:
+        return all_items, min(last_page, MAX_PAGINATION_PAGES)
+    seen_pages = {repr(items)}
+    for next_page in range(2, min(last_page, MAX_PAGINATION_PAGES) + 1):
         page_items, _ = fetch_page(next_page)
+        signature = repr(page_items)
+        if not page_items or signature in seen_pages:
+            break
         all_items.extend(page_items)
-    return all_items, last_page
+        seen_pages.add(signature)
+    return all_items, min(last_page, MAX_PAGINATION_PAGES)
 
 def submission_score(submission: dict[str, Any], mode: str) -> str:
     key = "completeTaskScore" if mode == "complete" else "partialTaskScore"

--- a/tests/test_contests.py
+++ b/tests/test_contests.py
@@ -99,6 +99,39 @@ class ContestRequestTests(unittest.TestCase):
             )
         self.assertEqual(items, [{"page": 1}, {"page": 2}, {"page": 3}])
 
+    def test_competition_pagination_is_capped_and_stops_on_repeated_pages(self) -> None:
+        requested: list[int] = []
+
+        def unique_page(*args: object, **kwargs: object) -> tuple[list[dict[str, int]], int]:
+            page = int(kwargs["page"])
+            requested.append(page)
+            return [{"page": page}], 10**9
+
+        with (
+            patch.object(contests, "MAX_PAGINATION_PAGES", 4),
+            patch.object(contests, "load_competitions_page", side_effect=unique_page),
+        ):
+            items = contests.load_competitions(
+                COOKIES, BEARER, page=None, page_size=20, featured=None
+            )
+        self.assertEqual(requested, [1, 2, 3, 4])
+        self.assertEqual(len(items), 4)
+
+        requested.clear()
+
+        def repeated_page(*args: object, **kwargs: object) -> tuple[list[dict[str, int]], int]:
+            page = int(kwargs["page"])
+            requested.append(page)
+            return [{"page": min(page, 2)}], 10**9
+
+        with patch.object(
+            contests, "load_competitions_page", side_effect=repeated_page
+        ):
+            contests.load_competitions(
+                COOKIES, BEARER, page=None, page_size=20, featured=None
+            )
+        self.assertEqual(requested, [1, 2, 3])
+
     def test_bare_api_lists_are_fetched_until_the_short_page(self) -> None:
         pages = {
             1: [{"id": 1}, {"id": 2}],

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -274,6 +274,43 @@ class SubmissionTests(unittest.TestCase):
             )
 
         self.assertIn("#2 partial None/? | complete None/?", output.getvalue())
+    def test_submission_pagination_is_capped_and_stops_on_repeated_pages(self) -> None:
+        requested: list[int] = []
+
+        def unique_request(**kwargs: object) -> tuple[int, str, dict[str, str]]:
+            page = int(kwargs["params"]["page"])  # type: ignore[index]
+            requested.append(page)
+            return 200, json.dumps({"items": [{"id": page}], "lastPage": 10**9}), {}
+
+        with (
+            patch.object(submissions, "MAX_PAGINATION_PAGES", 4),
+            patch.object(submissions, "api_request_text", side_effect=unique_request),
+        ):
+            items, last_page = submissions.load_submissions(
+                ("", ""), "token", "org", "contest", "7",
+                author=None, page=None, page_size=10, mode="partial",
+            )
+        self.assertEqual(requested, [1, 2, 3, 4])
+        self.assertEqual(len(items), 4)
+        self.assertEqual(last_page, 4)
+
+        requested.clear()
+
+        def repeated_request(**kwargs: object) -> tuple[int, str, dict[str, str]]:
+            page = int(kwargs["params"]["page"])  # type: ignore[index]
+            requested.append(page)
+            return 200, json.dumps(
+                {"items": [{"id": min(page, 2)}], "lastPage": 10**9}
+            ), {}
+
+        with patch.object(
+            submissions, "api_request_text", side_effect=repeated_request
+        ):
+            submissions.load_submissions(
+                ("", ""), "token", "org", "contest", "7",
+                author=None, page=None, page_size=10, mode="partial",
+            )
+        self.assertEqual(requested, [1, 2, 3])
 
     def test_polling_returns_first_non_pending_feedback(self) -> None:
         pending = {"id": "one", "state": "pending"}


### PR DESCRIPTION
## Summary
- cap server-declared competition and submission page counts
- fetch pages sequentially so only one request is active
- stop on empty or repeated pages
- preserve page order and unknown-page fallback behavior

## Tests
- `python3 -m unittest tests.test_contests tests.test_submissions -v` (30 passed)
- `git diff --check`

Closes #22