### PR TITLE
Serialize persistent context mutations

### DIFF
--- a/src/nitro_ai_judge_cli/shell.py
+++ b/src/nitro_ai_judge_cli/shell.py
@@ -17,8 +17,8 @@ from .state import (
     atomic_write,
     cached_items,
     load_context,
+    mutate_context,
     prepare_history,
-    save_context,
     selected_contest,
     selected_submission,
     selected_task,
@@ -154,17 +154,18 @@ def save_shell_history() -> None:
 
 
 def _back() -> None:
-    context = load_context()
-    if selected_submission(context):
-        context.pop("submission", None)
-    elif selected_task(context) is not None:
-        context.pop("task", None)
-        context.pop("submission", None)
-    elif selected_contest(context):
-        context.pop("contest", None)
-        context.pop("task", None)
-        context.pop("submission", None)
-    save_context(context)
+    def back(context: dict[str, Any]) -> None:
+        if selected_submission(context):
+            context.pop("submission", None)
+        elif selected_task(context) is not None:
+            context.pop("task", None)
+            context.pop("submission", None)
+        elif selected_contest(context):
+            context.pop("contest", None)
+            context.pop("task", None)
+            context.pop("submission", None)
+
+    mutate_context(back)
 
 
 def _contest_candidates(context: dict[str, Any]) -> list[dict[str, Any]]:

--- a/src/nitro_ai_judge_cli/state.py
+++ b/src/nitro_ai_judge_cli/state.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass
 import json
 import os
 import sys
 import tempfile
-from typing import Any
+from typing import Any, Callable, Iterator
+
+if os.name == "nt":
+    import msvcrt
+else:
+    import fcntl
 
 from .config import clean_env_value
 
@@ -223,15 +229,56 @@ def load_context() -> dict[str, Any]:
         return {}
 
 
-def save_context(value: dict[str, Any]) -> None:
+def _save_context_unlocked(value: dict[str, Any]) -> None:
     paths = ensure_state_dir()
     _write_json(paths.context, value)
 
 
+@contextmanager
+def _context_lock() -> Iterator[None]:
+    paths = ensure_state_dir()
+    path = f"{paths.context}.lock"
+    descriptor = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+    os.chmod(path, 0o600)
+    with os.fdopen(descriptor, "r+b", buffering=0) as lock:
+        if os.name == "nt":
+            if os.path.getsize(path) == 0:
+                lock.write(b"\0")
+            lock.seek(0)
+            msvcrt.locking(lock.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            if os.name == "nt":
+                lock.seek(0)
+                msvcrt.locking(lock.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+
+def save_context(value: dict[str, Any]) -> None:
+    with _context_lock():
+        _save_context_unlocked(value)
+
+
+def mutate_context(change: Callable[[dict[str, Any]], None]) -> dict[str, Any]:
+    with _context_lock():
+        context = load_context()
+        change(context)
+        _save_context_unlocked(context)
+        return context
+
+
 def clear_context() -> None:
-    context = load_context()
-    cache = context.get("cache")
-    save_context({"cache": cache} if isinstance(cache, dict) else {})
+    def clear(context: dict[str, Any]) -> None:
+        cache = context.get("cache")
+        context.clear()
+        if isinstance(cache, dict):
+            context["cache"] = cache
+
+    mutate_context(clear)
 
 
 def selected_contest(context: dict[str, Any] | None = None) -> tuple[str, str] | None:
@@ -279,53 +326,58 @@ def selected_submission(context: dict[str, Any] | None = None) -> str | None:
 
 
 def set_contest(contest: dict[str, Any]) -> dict[str, Any]:
-    context = load_context()
-    previous = selected_contest(context)
     org = str(contest.get("organizationSlug") or contest.get("org") or "")
     comp = str(contest.get("competitionSlug") or contest.get("comp") or "")
     if not org or not comp:
         raise ValueError("contest requires organizationSlug and competitionSlug")
-    context["contest"] = {**contest, "organizationSlug": org, "competitionSlug": comp}
-    if previous != (org, comp):
-        context.pop("task", None)
-        context.pop("submission", None)
-    save_context(context)
-    return context
+
+    def select(context: dict[str, Any]) -> None:
+        previous = selected_contest(context)
+        context["contest"] = {
+            **contest,
+            "organizationSlug": org,
+            "competitionSlug": comp,
+        }
+        if previous != (org, comp):
+            context.pop("task", None)
+            context.pop("submission", None)
+
+    return mutate_context(select)
 
 
 def set_task(task: dict[str, Any] | str | int) -> dict[str, Any]:
-    context = load_context()
     task_value = {"id": str(task)} if not isinstance(task, dict) else dict(task)
     if task_value.get("id") is None:
         raise ValueError("task requires an id")
     task_value["id"] = str(task_value["id"])
-    if selected_task(context) != task_value["id"]:
-        context.pop("submission", None)
-    context["task"] = task_value
-    save_context(context)
-    return context
+
+    def select(context: dict[str, Any]) -> None:
+        if selected_task(context) != task_value["id"]:
+            context.pop("submission", None)
+        context["task"] = task_value
+
+    return mutate_context(select)
 
 
 def set_submission(submission: dict[str, Any] | str) -> dict[str, Any]:
-    context = load_context()
     value = {"id": submission} if isinstance(submission, str) else dict(submission)
-    context["submission"] = value
-    save_context(context)
-    return context
+
+    return mutate_context(lambda context: context.__setitem__("submission", value))
 
 
 def update_cache(kind: str, key: str, items: list[dict[str, Any]]) -> None:
-    context = load_context()
-    cache = context.setdefault("cache", {})
-    if not isinstance(cache, dict):
-        cache = {}
-        context["cache"] = cache
-    bucket = cache.setdefault(kind, {})
-    if not isinstance(bucket, dict):
-        bucket = {}
-        cache[kind] = bucket
-    bucket[key] = items
-    save_context(context)
+    def update(context: dict[str, Any]) -> None:
+        cache = context.setdefault("cache", {})
+        if not isinstance(cache, dict):
+            cache = {}
+            context["cache"] = cache
+        bucket = cache.setdefault(kind, {})
+        if not isinstance(bucket, dict):
+            bucket = {}
+            cache[kind] = bucket
+        bucket[key] = items
+
+    mutate_context(update)
 
 
 def cached_items(kind: str, key: str) -> list[dict[str, Any]]:

--- a/tests/test_state_completion.py
+++ b/tests/test_state_completion.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import stat
 import sys
 import tempfile
+import threading
 import unittest
 from unittest.mock import patch
 
@@ -271,6 +272,44 @@ class StateTests(unittest.TestCase):
         self.assertNotIn("contest", context)
         self.assertNotIn("task", context)
         self.assertIn("cache", context)
+
+    def test_concurrent_cache_transactions_retain_both_updates(self) -> None:
+        self.set_state_root()
+        first_saving = threading.Event()
+        release_first = threading.Event()
+        second_finished = threading.Event()
+        real_save = state._save_context_unlocked
+
+        def delayed_save(value: dict[str, object]) -> None:
+            if not first_saving.is_set():
+                first_saving.set()
+                release_first.wait(2)
+            real_save(value)
+
+        def update(key: str) -> None:
+            state.update_cache("tasks", key, [{"id": key}])
+            if key == "b":
+                second_finished.set()
+
+        with patch.object(state, "_save_context_unlocked", side_effect=delayed_save):
+            first = threading.Thread(target=update, args=("a",))
+            second = threading.Thread(target=update, args=("b",))
+            first.start()
+            self.assertTrue(first_saving.wait(1))
+            second.start()
+            try:
+                self.assertFalse(second_finished.wait(0.05))
+            finally:
+                release_first.set()
+            first.join(2)
+            second.join(2)
+
+        self.assertFalse(first.is_alive())
+        self.assertFalse(second.is_alive())
+        self.assertEqual(
+            state.load_context()["cache"]["tasks"],
+            {"a": [{"id": "a"}], "b": [{"id": "b"}]},
+        )
 
     def test_explicit_empty_context_does_not_fall_back_to_disk(self) -> None:
         with patch.object(state, "load_context", side_effect=AssertionError("disk read")):


### PR DESCRIPTION
## Summary
- lock complete context read-modify-write transactions across processes
- route selection, cache, clearing, and shell back-navigation through one mutation path
- keep atomic replacement and private lock-file permissions on Unix and Windows
- prove concurrent cache writes serialize and retain both updates

## Tests
- `python3 -m unittest tests.test_state_completion tests.test_shell tests.test_cli -v` (75 passed)
- `git diff --check`

Closes #21