### PR TITLE
fix: show Play manager lifecycle progress

### DIFF
--- a/src/nitro_ai_judge_cli/play.py
+++ b/src/nitro_ai_judge_cli/play.py
@@ -34,6 +34,11 @@ from .ui import Spinner
 
 PLAY_WAIT_TIMEOUT = 120
 MANAGER_SETUP_LABEL = "Installing Play manager (pulling image and waiting for health)\u2026"
+MANAGER_ACTION_LABELS = {
+    "start": "Starting Play manager\u2026",
+    "stop": "Stopping Play manager\u2026",
+    "restart": "Restarting Play manager\u2026",
+}
 PLAY_ACTIONS = {
     "pull",
     "play",
@@ -448,7 +453,11 @@ def cmd_manager(args: argparse.Namespace) -> int:
         ):
             _install_or_repair_manager()
             return 0
-        manager_compose_action(action)
+        spinner = Spinner(MANAGER_ACTION_LABELS[action], stream=sys.stdout).start()
+        try:
+            manager_compose_action(action)
+        finally:
+            spinner.stop()
         print(f"Play manager {action} complete")
         return 0
     if action == "open":

--- a/tests/test_play.py
+++ b/tests/test_play.py
@@ -298,6 +298,9 @@ class PlayCommandTests(unittest.TestCase):
             ("stop", False),
         ):
             args = cli.build_parser().parse_args(["play", "manager", action])
+            output = io.StringIO()
+            spinner = Mock()
+            spinner.start.return_value = spinner
             with (
                 self.subTest(action=action, migrates=migrates),
                 patch.object(
@@ -306,7 +309,8 @@ class PlayCommandTests(unittest.TestCase):
                 patch.object(play, "load_manager_config", return_value={"image": "saved"}),
                 patch.object(play, "manager_container_exists", return_value=True),
                 patch.object(play, "manager_compose_action") as compose_action,
-                redirect_stdout(io.StringIO()),
+                patch.object(play, "Spinner", return_value=spinner) as spinner_class,
+                redirect_stdout(output),
             ):
                 self.assertEqual(play.cmd_manager(args), 0)
             if action == "stop":
@@ -315,8 +319,13 @@ class PlayCommandTests(unittest.TestCase):
                 migrate.assert_called_once_with()
             if migrates:
                 compose_action.assert_not_called()
+                spinner_class.assert_not_called()
             else:
                 compose_action.assert_called_once_with(action)
+                spinner_class.assert_called_once_with(
+                    play.MANAGER_ACTION_LABELS[action], stream=output
+                )
+                spinner.stop.assert_called_once_with()
 
     def test_long_action_is_polled_and_returns_snapshot(self) -> None:
         client = FakeClient()


### PR DESCRIPTION
## Summary

- show action-specific progress while starting, stopping, or restarting the Play manager
- reuse the existing TTY-aware stdout spinner and always clean it up
- keep install/repair migration progress unchanged

## Verification

- uv run --extra manager python3 -m unittest discover -s tests -v: 233 passed, 2 skipped
- real PTY runs of naij play manager stop and start showed animated frames and completion receipts
- Play manager returned healthy after restart