### PR TITLE
Handle malformed auth state and login redirects

### DIFF
--- a/src/nitro_ai_judge_cli/api.py
+++ b/src/nitro_ai_judge_cli/api.py
@@ -132,7 +132,8 @@ class APIClient:
 
 def decode_session(session_cookie: str) -> dict[str, Any] | None:
     try:
-        return json.loads(base64.b64decode(urllib.parse.unquote(session_cookie)))
+        value = json.loads(base64.b64decode(urllib.parse.unquote(session_cookie)))
+        return value if isinstance(value, dict) else None
     except Exception:
         return None
 
@@ -153,7 +154,12 @@ def encode_session(state: dict[str, Any]) -> str | None:
 def get_auth(state: dict[str, Any]) -> tuple[str | None, str | None, str] | None:
     cf = session = None
     access_token = state.get("access_token") or state.get("accessToken") or ""
-    for cookie in state.get("cookies", []):
+    if not isinstance(access_token, str):
+        access_token = ""
+    cookies = state.get("cookies", [])
+    for cookie in cookies if isinstance(cookies, list) else []:
+        if not isinstance(cookie, dict):
+            continue
         if cookie.get("name") == "cf_clearance":
             cf = cookie.get("value")
         elif cookie.get("name") == "Cookie":
@@ -161,7 +167,10 @@ def get_auth(state: dict[str, Any]) -> tuple[str | None, str | None, str] | None
     if session:
         decoded = decode_session(session)
         if decoded:
-            access_token = decoded.get("accessToken", "")
+            decoded_access_token = decoded.get("accessToken", "")
+            access_token = (
+                decoded_access_token if isinstance(decoded_access_token, str) else ""
+            )
     else:
         session = encode_session(state)
     if not access_token:
@@ -451,7 +460,10 @@ def save_token_state(tokens: dict[str, Any], username: str | None = None) -> Non
 def refresh_saved_tokens(state: dict[str, Any]) -> dict[str, Any] | None:
     refresh_token = state.get("refresh_token") or state.get("refreshToken")
     if not refresh_token:
-        for cookie in state.get("cookies", []):
+        cookies = state.get("cookies", [])
+        for cookie in cookies if isinstance(cookies, list) else []:
+            if not isinstance(cookie, dict):
+                continue
             if cookie.get("name") == "Cookie":
                 decoded = decode_session(cookie.get("value", "")) or {}
                 refresh_token = decoded.get("refreshToken")
@@ -536,7 +548,11 @@ def cmd_login(username: str | None, password: str | None) -> int:
             print("Aborted.")
             return 1
 
-    result = do_login(username, password)
+    try:
+        result = do_login(username, password)
+    except RedirectError as exc:
+        print(f"Login failed: {exc}")
+        return 1
 
     if result["success"] and result.get("tokens"):
         save_token_state(result["tokens"], result.get("username"))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -210,6 +210,16 @@ class PayloadTests(unittest.TestCase):
 
 
 class AuthenticationTests(unittest.TestCase):
+    def test_malformed_credential_fields_do_not_raise(self) -> None:
+        self.assertEqual(
+            api.get_auth({"access_token": "abc", "cookies": None}),
+            (None, None, "abc"),
+        )
+        self.assertIsNone(api.get_auth({"access_token": 123, "cookies": [None]}))
+
+        encoded = urllib.parse.quote(base64.b64encode(b"[]").decode())
+        self.assertIsNone(api.decode_session(encoded))
+
     def test_login_request_and_success_parsing(self) -> None:
         payload = {"accessToken": "access", "refreshToken": "refresh"}
         with patch.object(
@@ -336,6 +346,19 @@ class AuthenticationTests(unittest.TestCase):
 
         self.assertNotIn("visible-secret", output.getvalue())
         self.assertIn("[redacted]", output.getvalue())
+    def test_cmd_login_reports_redirect_errors_without_traceback(self) -> None:
+        for error in (
+            api.AuthenticationRedirect("Authentication required"),
+            api.RedirectError("Refused cross-origin redirect"),
+        ):
+            with self.subTest(error=type(error).__name__):
+                output = io.StringIO()
+                with (
+                    patch.object(api, "do_login", side_effect=error),
+                    contextlib.redirect_stdout(output),
+                ):
+                    self.assertEqual(api.cmd_login("alice", "secret"), 1)
+                self.assertEqual(output.getvalue().strip(), f"Login failed: {error}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- tolerate malformed legacy credential fields without tracebacks
- accept only object-shaped decoded sessions
- report login redirect safety failures as normal login errors

## Tests
- `PYTHONPATH=src python3 -m unittest tests.test_api tests.test_state_completion -v` (55 passed)
- `git diff --check`

Closes #20
Closes #28