### PR TITLE
fix: let TUI Play waits exit promptly

### DIFF
--- a/src/nitro_ai_judge_cli/play_manager_client.py
+++ b/src/nitro_ai_judge_cli/play_manager_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 import time
 from typing import Any, Callable, Iterator
 import urllib.error
@@ -163,10 +164,13 @@ class ManagerClient:
         timeout: float = 600,
         interval: float = 0.5,
         progress: Callable[[dict[str, Any]], None] | None = None,
+        stop_event: threading.Event | None = None,
     ) -> dict[str, Any]:
         deadline = time.monotonic() + timeout
         last_sequence = -1
         while time.monotonic() < deadline:
+            if stop_event is not None and stop_event.is_set():
+                raise InterruptedError("Stopped waiting for Play operation")
             operation = self.operation(operation_id)
             events = operation.get("events", [])
             for event in events if isinstance(events, list) else []:
@@ -186,7 +190,11 @@ class ManagerClient:
                     tuple(str(item) for item in error.get("logs", [])[-40:]),
                     500,
                 )
-            time.sleep(interval)
+            if stop_event is not None:
+                if stop_event.wait(interval):
+                    raise InterruptedError("Stopped waiting for Play operation")
+            else:
+                time.sleep(interval)
         raise ManagerConnectionError(
             f"Play operation did not finish within {int(timeout)} seconds"
         )

--- a/src/nitro_ai_judge_cli/tui.py
+++ b/src/nitro_ai_judge_cli/tui.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 import os
+import threading
 from typing import Any, Callable
 import webbrowser
 
@@ -239,6 +240,40 @@ def _load_submission_with_auth(
     **kwargs: Any,
 ) -> dict[str, Any]:
     return load_submission(submission_id, cookies, bearer, **kwargs)
+
+
+async def _wait_for_play_operation(
+    client: ManagerClient, operation_id: str, *, timeout: float
+) -> dict[str, Any]:
+    stop_event = threading.Event()
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+
+    def wait() -> None:
+        try:
+            result = client.wait_operation(
+                operation_id,
+                timeout=timeout,
+                stop_event=stop_event,
+            )
+        except BaseException as exc:
+            callback = lambda exc=exc: (
+                not future.done() and future.set_exception(exc)
+            )
+        else:
+            callback = lambda result=result: (
+                not future.done() and future.set_result(result)
+            )
+        try:
+            loop.call_soon_threadsafe(callback)
+        except RuntimeError:
+            pass
+
+    threading.Thread(target=wait, daemon=True).start()
+    try:
+        return await future
+    finally:
+        stop_event.set()
 
 
 class LoginRequired(RuntimeError):
@@ -2320,8 +2355,8 @@ class NitroTUI(App[int]):
                     pull="missing" if action in {"play", "recreate"} else None,
                     wait_timeout=120 if action in {"play", "recreate"} else None,
                 )
-                await asyncio.to_thread(
-                    client.wait_operation,
+                await _wait_for_play_operation(
+                    client,
                     str(accepted["operation_id"]),
                     timeout=600,
                 )

--- a/tests/test_play.py
+++ b/tests/test_play.py
@@ -4,6 +4,7 @@ import io
 import json
 import os
 import tempfile
+import threading
 import unittest
 from contextlib import redirect_stdout
 from types import SimpleNamespace
@@ -632,6 +633,17 @@ class ManagerConfigurationTests(unittest.TestCase):
 
 
 class ManagerClientTests(unittest.TestCase):
+    def test_wait_operation_honors_local_stop_without_remote_cancel(self) -> None:
+        client = ManagerClient("http://localhost", "token")
+        stop_event = threading.Event()
+        stop_event.set()
+        with (
+            patch.object(client, "operation") as operation,
+            self.assertRaises(InterruptedError),
+        ):
+            client.wait_operation("operation", stop_event=stop_event)
+        operation.assert_not_called()
+
     def test_follow_logs_decodes_ndjson_to_plain_lines(self) -> None:
         class Response(list):
             def __enter__(self):

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import sys
 import tempfile
 import threading
+import time
 import unittest
 from unittest.mock import patch
 
@@ -76,7 +77,9 @@ class FakeManager:
         self.actions.append(action)
         return {"operation_id": f"operation-{action}"}
 
-    def wait_operation(self, operation_id: str, *, timeout: float = 600) -> dict:
+    def wait_operation(
+        self, operation_id: str, *, timeout: float = 600, **_options: object
+    ) -> dict:
         return {"status": "complete", "result": dict(PLAY_STATUS)}
 
     def open_info(self, org: str, competition: str) -> dict:
@@ -133,6 +136,37 @@ class TUIEntrypointTests(unittest.TestCase):
             self.assertEqual(tui.run_tui(), 1)
         app.assert_not_called()
         self.assertIn("Play manager migration failed: boom", output.getvalue())
+
+    def test_cancelled_play_wait_does_not_hold_asyncio_shutdown(self) -> None:
+        class WaitingManager:
+            def __init__(self) -> None:
+                self.started = threading.Event()
+
+            def wait_operation(
+                self,
+                _operation_id: str,
+                *,
+                timeout: float,
+                stop_event: threading.Event,
+            ) -> dict:
+                self.started.set()
+                time.sleep(2)
+                return {"status": "complete"}
+
+        manager = WaitingManager()
+
+        async def cancel_wait() -> None:
+            task = asyncio.create_task(
+                tui._wait_for_play_operation(manager, "operation", timeout=5)  # type: ignore[arg-type]
+            )
+            self.assertTrue(await asyncio.to_thread(manager.started.wait, 1))
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+        started = time.monotonic()
+        asyncio.run(cancel_wait())
+        self.assertLess(time.monotonic() - started, 1)
 
 
 class TUIAuthSessionTests(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
- make Play operation polling cooperatively stoppable without cancelling the server operation
- run the blocking wait on a daemon thread so asyncio shutdown never joins an uncooperative call
- cover local cancellation and process-runner quit latency

## Tests
- `PYTHONPATH=src python3 -m unittest tests.test_tui tests.test_play` (56 passed)
- `git diff --check`

Closes #35