### PR TITLE
Complete CLI routing and shell completion coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,12 +391,13 @@ Shell conveniences:
 
 ## Native completion
 
-Generate completion for zsh, bash, or fish:
+Generate completion for zsh, bash, fish, or PowerShell:
 
 ```bash
 naij completion zsh
 naij completion bash
 naij completion fish
+naij completion powershell
 ```
 
 For the current shell session:
@@ -410,6 +411,9 @@ source <(naij completion bash)
 
 # fish
 naij completion fish | source
+
+# PowerShell
+naij completion powershell | Out-String | Invoke-Expression
 ```
 
 Completion resolves the current argument slot and shows only its next useful level. It does not mix options with an available contest, task, or submission; typing `-` switches immediately to remaining valid options. It lazily fetches a missing entity list on the first relevant Tab and saves it in the context cache. It fetches all competitions, only the selected or supplied competition's tasks, or the current user's partial and complete submissions for the selected task. Existing cache entries, including empty lists, suppress later requests; authentication and network failures stay silent and can be retried on a later Tab. Bare native completion remains command-only, while a blank interactive prompt offers only entities at the current context level.

--- a/src/nitro_ai_judge_cli/cli.py
+++ b/src/nitro_ai_judge_cli/cli.py
@@ -324,7 +324,7 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_parser("show", help="Show the selected item")
 
     completion = sub.add_parser("completion", help="Generate native shell completion")
-    completion.add_argument("shell", choices=("zsh", "bash", "fish"))
+    completion.add_argument("shell", choices=("zsh", "bash", "fish", "powershell"))
 
     internal = sub.add_parser("__complete", add_help=False)
     internal.add_argument("words", nargs=argparse.REMAINDER)
@@ -499,8 +499,16 @@ def _dispatch_authenticated(args: argparse.Namespace) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
-    if "__complete" not in argv and "play" in argv:
-        index = argv.index("play")
+    index = 0
+    while index < len(argv):
+        option = argv[index].split("=", 1)[0]
+        if option in {"--submission-proxy"}:
+            index += 1
+        elif option in {"--api-url", "--state-dir"}:
+            index += 1 if "=" in argv[index] else 2
+        else:
+            break
+    if index < len(argv) and argv[index] == "play":
         argv = [*argv[: index + 1], *normalize_play_argv(argv[index + 1 :])]
     parser = build_parser()
     args = parser.parse_args(argv)

--- a/src/nitro_ai_judge_cli/completion.py
+++ b/src/nitro_ai_judge_cli/completion.py
@@ -21,7 +21,7 @@ SHELL_COMMANDS = (
 GLOBAL_OPTIONS = ("--api-url", "--submission-proxy", "--state-dir", "--help")
 PLAY_ACTIONS = (
     "play", "pull", "start", "stop", "restart", "recreate",
-    "delete-container", "delete-image", "delete-workspace", "logs", "status", "cancel", "open", "manager",
+    "delete-container", "delete-image", "delete-workspace", "logs", "status", "ps", "cancel", "open", "manager",
 )
 MANAGER_ACTIONS = (
     "install", "update", "status", "open", "start", "stop", "restart",
@@ -72,6 +72,7 @@ PLAY_OPTION_GROUPS = {
     "delete-container": (("--yes",), ("--help",)),
     "delete-image": (("--yes",), ("--help",)),
     "status": (("--yes",), ("--help",)),
+    "ps": (("--yes",), ("--help",)),
     "cancel": (("--yes",), ("--help",)),
     "open": (("--yes",), ("--help",)),
     "manager-install": (
@@ -360,6 +361,8 @@ def _task_entities(
         explicit = _contest_ref(positionals[0], context)
         if explicit and len(positionals) == 1:
             return [("tasks", explicit)]
+        if len(positionals) == 2 and all("/" not in item for item in positionals):
+            return [("tasks", (positionals[0], positionals[1]))]
         return None
     if prefix:
         result: list[tuple[str, tuple[str, ...] | None]] = []
@@ -553,7 +556,7 @@ def candidates(
     if command == "completion":
         if _positionals(command, arguments):
             return _remaining_options(command, arguments, prefix)
-        return _matches(("zsh", "bash", "fish"), prefix)
+        return _matches(("zsh", "bash", "fish", "powershell"), prefix)
 
     if command == "play":
         positionals = _positionals(command, arguments)
@@ -643,4 +646,33 @@ end
 complete -c naij -f -a '(__naij_complete)'
 complete -c nitro-cli -f -a '(__naij_complete)'
 """
+    if shell == "powershell":
+        return r'''Register-ArgumentCompleter -Native -CommandName naij,nitro-cli -ScriptBlock {
+  param($wordToComplete, $commandAst, $cursorPosition)
+  $words = @(
+    $commandAst.CommandElements | Select-Object -Skip 1 | ForEach-Object {
+      if ($_ -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+        $_.Value
+      } else {
+        $_.Extent.Text
+      }
+    }
+  )
+  if ($wordToComplete -and $words.Count) {
+    $words = @($words | Select-Object -SkipLast 1)
+  }
+  $words += $wordToComplete
+  naij __complete -- @words | ForEach-Object {
+    $candidate = $_
+    $completion = if ($candidate -match "[\s'\"]") {
+      "'" + $candidate.Replace("'", "''") + "'"
+    } else {
+      $candidate
+    }
+    [System.Management.Automation.CompletionResult]::new(
+      $completion, $candidate, 'ParameterValue', $candidate
+    )
+  }
+}
+'''
     raise ValueError(f"unsupported shell: {shell}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,6 +64,25 @@ class EntrypointTests(unittest.TestCase):
         self.assertEqual(result, (0, "up\n", ""))
         candidates.assert_called_once_with(["play", ""])
 
+    def test_literal_play_option_values_do_not_trigger_play_normalization(self) -> None:
+        with patch.object(cli, "configure_state_dir") as configure, patch.object(
+            cli, "load_context", return_value={}
+        ):
+            result = invoke(cli.main, ["--state-dir", "play", "use"])
+        self.assertEqual(result[0], 0)
+        configure.assert_called_once_with("play")
+
+        auth = ({}, ("", ""), "token")
+        with patch.object(cli, "require_auth", return_value=auth), patch.object(
+            cli, "load_context", return_value={
+                "contest": {"org": "org", "comp": "contest"},
+                "task": {"id": "task"},
+            }
+        ), patch.object(cli, "cmd_submit", return_value=0) as submit:
+            result = invoke(cli.main, ["submit", "-o", "play"])
+        self.assertEqual(result[0], 0)
+        self.assertEqual(submit.call_args.args[5], "play")
+
     def test_python_module_runs_canonical_help(self) -> None:
         environment = os.environ.copy()
         environment["PYTHONPATH"] = str(ROOT / "src")

--- a/tests/test_state_completion.py
+++ b/tests/test_state_completion.py
@@ -6,6 +6,7 @@ import json
 import os
 from pathlib import Path
 import stat
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -390,6 +391,12 @@ class CompletionTests(unittest.TestCase):
                     completion.candidates([command, contest, ""], context),
                     ["1", "2", "3"],
                 )
+                self.assertEqual(
+                    completion.candidates(
+                        [command, "ceoai", "ceoai-2026-day-1", ""], context
+                    ),
+                    ["1", "2", "3"],
+                )
 
     def test_task_slots_distinguish_inherited_and_explicit_targets(self) -> None:
         context = self.context()
@@ -470,6 +477,10 @@ class CompletionTests(unittest.TestCase):
         )
         self.assertEqual(
             completion.candidates(["play", "cancel", ""], context),
+            ["--help", "--yes"],
+        )
+        self.assertEqual(
+            completion.candidates(["play", "ps", ""], context),
             ["--help", "--yes"],
         )
         self.assertEqual(
@@ -638,7 +649,7 @@ class CompletionTests(unittest.TestCase):
                 os.chdir(old_cwd)
 
     def test_generated_scripts_register_both_names_but_call_naij(self) -> None:
-        for shell in ("zsh", "bash", "fish"):
+        for shell in ("zsh", "bash", "fish", "powershell"):
             with self.subTest(shell=shell):
                 generated = completion.script(shell)
                 self.assertIn("naij", generated)
@@ -647,10 +658,26 @@ class CompletionTests(unittest.TestCase):
                 self.assertNotIn("nitro-cli __complete", generated)
         self.assertIn('"${words[@]:1}"', completion.script("zsh"))
         self.assertIn("commandline -ct", completion.script("fish"))
+        powershell = completion.script("powershell")
+        self.assertIn("Register-ArgumentCompleter -Native", powershell)
+        self.assertIn("$wordToComplete", powershell)
+        self.assertIn("CompletionResult", powershell)
+
+    @unittest.skipUnless(os.name == "nt", "PowerShell smoke test runs on Windows CI")
+    def test_generated_powershell_script_parses_on_windows(self) -> None:
+        result = subprocess.run(
+            ["powershell", "-NoProfile", "-NonInteractive", "-Command", "-"],
+            input=completion.script("powershell"),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_unknown_completion_shell_is_rejected(self) -> None:
         with self.assertRaisesRegex(ValueError, "unsupported shell"):
-            completion.script("powershell")
+            completion.script("nushell")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- identify the real root command before Play shorthand normalization
- complete split contest targets and the public `play ps` action
- add native PowerShell completion for both entrypoints
- document and smoke-test PowerShell installation

## Tests
- `PYTHONPATH=src python3 -m unittest tests.test_cli tests.test_state_completion -v` (59 passed, 1 skipped off Windows)
- `git diff --check`

Closes #24
Closes #29
Closes #30
Closes #59