### PR TITLE
feat: add cache controls and offline browsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ refresh remains an access-denied error rather than reopening login repeatedly.
 Loaded task statements are merged into the task cache, so reopening a task can
 show its full statement before the next network refresh.
 
+Use `naij ls --offline` or `naij show --offline` to browse the selected cached
+scope without authentication or network access. Cached output is marked and
+reports that freshness is unavailable. Inspect or invalidate stale entries with
+`naij cache status` and `naij cache clear [contests|tasks|submissions|all]`;
+clearing cache never changes credentials or the current selection.
+
 Release screenshots and the keyboard walkthrough will be added under
 `docs/assets/` with the `v3.0.0` release capture; the recording contract is in
 [`docs/assets/README.md`](docs/assets/README.md).

--- a/src/nitro_ai_judge_cli/cli.py
+++ b/src/nitro_ai_judge_cli/cli.py
@@ -22,6 +22,8 @@ from .contests import (
     find_task,
     load_tasks,
     print_competitions,
+    print_task,
+    print_tasks,
     task_number,
 )
 from .play import (
@@ -35,6 +37,7 @@ from .shell import run_shell
 from .state import (
     CredentialsError,
     clear_credentials,
+    clear_cache,
     clear_context,
     configure_state_dir,
     load_context,
@@ -54,6 +57,8 @@ from .submissions import (
     cmd_submissions,
     cmd_submit,
     get_username,
+    print_submission_details,
+    print_submissions,
 )
 
 
@@ -246,6 +251,180 @@ def _cmd_use(args: argparse.Namespace) -> int:
     return _show_context(load_context())
 
 
+def _cache_entry(
+    context: dict[str, Any], kind: str, key: str
+) -> list[dict[str, Any]] | None:
+    cache = context.get("cache")
+    bucket = cache.get(kind) if isinstance(cache, dict) else None
+    if not isinstance(bucket, dict) or key not in bucket:
+        return None
+    items = bucket[key]
+    if not isinstance(items, list):
+        return None
+    return [item for item in items if isinstance(item, dict)]
+
+
+def _offline_error(message: str, command: str) -> int:
+    print(f"Error: {message}; run `{command}` without --offline to refresh.")
+    return 1
+
+
+def _dispatch_offline(args: argparse.Namespace) -> int:
+    context = load_context()
+    contest = selected_contest(context)
+    task_id = selected_task(context)
+    submission_id = selected_submission(context)
+
+    if args.cmd == "ls":
+        if not contest:
+            items = _cache_entry(context, "contests", "featured")
+            if items is None:
+                items = _cache_entry(context, "contests", "all")
+            if items is None:
+                return _offline_error("no cached competitions are available", "naij ls")
+            print("[cached; freshness unavailable]")
+            if items:
+                print_competitions(items)
+            else:
+                print("No competitions found")
+            return 0
+        if task_id is None:
+            items = _cache_entry(context, "tasks", f"{contest[0]}/{contest[1]}")
+            if items is None:
+                return _offline_error(
+                    f"no cached tasks are available for {contest[0]}/{contest[1]}",
+                    "naij ls",
+                )
+            print("[cached; freshness unavailable]")
+            print_tasks(items)
+            return 0
+        key = f"{contest[0]}/{contest[1]}/{task_id}"
+        items = _cache_entry(context, "submissions", key)
+        if items is None:
+            return _offline_error(
+                f"no cached submissions are available for {key}", "naij ls"
+            )
+        print("[cached; freshness unavailable]")
+        if not items:
+            print_submissions([], "partial")
+        for item in items:
+            mode = str(
+                item.get("_mode")
+                or ("complete" if "completeTaskScore" in item else "partial")
+            )
+            print_submissions([item], mode)
+        return 0
+
+    if not contest:
+        return _offline_error("no contest is selected", "naij use ORG/COMP")
+
+    if submission_id:
+        if task_id is None:
+            return _offline_error(
+                "the selected submission has no task context", "naij use"
+            )
+        key = f"{contest[0]}/{contest[1]}/{task_id}"
+        items = _cache_entry(context, "submissions", key)
+        submission = next(
+            (
+                item
+                for item in items or []
+                if str(item.get("id")) == submission_id
+            ),
+            None,
+        )
+        if submission is None:
+            return _offline_error(
+                f"submission {submission_id} is missing from the cached {key} list",
+                "naij show",
+            )
+        selected = context.get("submission")
+        if isinstance(selected, dict) and str(selected.get("id")) == submission_id:
+            submission = {**submission, **selected}
+        print("[cached; freshness unavailable]")
+        print_submission_details(submission)
+        return 0
+
+    if task_id is not None:
+        items = _cache_entry(context, "tasks", f"{contest[0]}/{contest[1]}")
+        task = next(
+            (item for item in items or [] if str(item.get("id")) == task_id), None
+        )
+        if task is None:
+            return _offline_error(
+                f"task {task_id} is missing from the cached task list", "naij show"
+            )
+        selected = context.get("task")
+        if isinstance(selected, dict) and str(selected.get("id")) == task_id:
+            task = {**task, **selected}
+        if "statement" not in task:
+            return _offline_error(
+                f"cached details for task {task_id} are incomplete", "naij show"
+            )
+        display_id = selected_task_number(context) or task_id
+        print("[cached; freshness unavailable]")
+        if display_id != task_id:
+            print(f"Task number: {display_id}")
+        print_task(task_id, task)
+        return 0
+
+    cache = context.get("cache")
+    bucket = cache.get("contests") if isinstance(cache, dict) else None
+    cached_contest = None
+    if isinstance(bucket, dict):
+        for values in bucket.values():
+            if not isinstance(values, list):
+                continue
+            cached_contest = next(
+                (
+                    item
+                    for item in values
+                    if isinstance(item, dict)
+                    and selected_contest({"contest": item}) == contest
+                ),
+                None,
+            )
+            if cached_contest is not None:
+                break
+    if cached_contest is None:
+        return _offline_error(
+            f"{contest[0]}/{contest[1]} is missing from the competition cache",
+            "naij show",
+        )
+    print("[cached; freshness unavailable]")
+    print_competitions([cached_contest])
+    return 0
+
+
+def _cmd_cache(args: argparse.Namespace) -> int:
+    if args.cache_action == "clear":
+        clear_cache(args.kind)
+        print(f"Cleared {args.kind} cache.")
+        return 0
+
+    cache = load_context().get("cache")
+    print("Cache status (freshness unavailable):")
+    found = False
+    if isinstance(cache, dict):
+        for kind, bucket in sorted(cache.items()):
+            if not isinstance(bucket, dict):
+                continue
+            if not bucket:
+                print(f"{kind}: 0 scopes, 0 records")
+                found = True
+            for scope, items in sorted(bucket.items()):
+                count = (
+                    len([item for item in items if isinstance(item, dict)])
+                    if isinstance(items, list)
+                    else 0
+                )
+                print(f"{kind}/{scope}: {count} records")
+                found = True
+    if not found:
+        print("(empty)")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="naij",
@@ -347,8 +526,23 @@ def build_parser() -> argparse.ArgumentParser:
     use.add_argument("selection", nargs="*")
     use.add_argument("--clear", action="store_true")
 
-    sub.add_parser("ls", help="List items at the selected context level")
-    sub.add_parser("show", help="Show the selected item")
+    listing = sub.add_parser("ls", help="List items at the selected context level")
+    listing.add_argument("--offline", action="store_true", help="Use cached data only")
+    show = sub.add_parser("show", help="Show the selected item")
+    show.add_argument("--offline", action="store_true", help="Use cached data only")
+
+    cache = sub.add_parser("cache", help="Inspect or clear cached data")
+    cache_actions = cache.add_subparsers(
+        dest="cache_action", required=True, metavar="ACTION"
+    )
+    cache_actions.add_parser("status", help="Show cached scopes and record counts")
+    cache_clear = cache_actions.add_parser("clear", help="Clear cached data")
+    cache_clear.add_argument(
+        "kind",
+        nargs="?",
+        choices=("contests", "tasks", "submissions", "all"),
+        default="all",
+    )
 
     completion = sub.add_parser("completion", help="Generate native shell completion")
     completion.add_argument("shell", choices=("zsh", "bash", "fish", "powershell"))
@@ -576,6 +770,10 @@ def main(argv: list[str] | None = None) -> int:
         if conflicts:
             print(f"Error: --list cannot be used with {', '.join(conflicts)}")
             return 1
+    if args.cmd == "cache":
+        return _cmd_cache(args)
+    if args.cmd in {"ls", "show"} and args.offline:
+        return _dispatch_offline(args)
     if not args.cmd:
         return run_shell(lambda words: main(words))
     if args.cmd == "login":

--- a/src/nitro_ai_judge_cli/completion.py
+++ b/src/nitro_ai_judge_cli/completion.py
@@ -12,7 +12,7 @@ from .state import load_context, selected_contest, selected_submission, selected
 COMMANDS = (
     "login", "logout", "tui", "contests", "tasks", "task", "download-data", "play", "submit",
     "submissions", "submission", "set-final", "unset-final", "use", "ls",
-    "show", "completion",
+    "show", "cache", "completion",
 )
 SHELL_COMMANDS = (
     "help", "cd", "pwd", "l", "h", "?", "q", "quit", "exit", "..",
@@ -55,6 +55,9 @@ OPTION_GROUPS = {
     "set-final": (("--help",),),
     "unset-final": (("--help",),),
     "use": (("--clear",), ("--help",)),
+    "ls": (("--offline",), ("--help",)),
+    "show": (("--offline",), ("--help",)),
+    "cache": (("--help",),),
     "completion": (("--help",),),
 }
 PLAY_OPTION_GROUPS = {
@@ -563,6 +566,14 @@ def candidates(
         if _positionals(command, arguments):
             return _remaining_options(command, arguments, prefix)
         return _matches(("zsh", "bash", "fish", "powershell"), prefix)
+
+    if command == "cache":
+        positionals = _positionals(command, arguments)
+        if not positionals:
+            return _matches(("status", "clear"), prefix)
+        if positionals[0] == "clear" and len(positionals) == 1:
+            return _matches(("contests", "tasks", "submissions", "all"), prefix)
+        return _remaining_options(command, arguments, prefix)
 
     if command == "play":
         positionals = _positionals(command, arguments)

--- a/src/nitro_ai_judge_cli/state.py
+++ b/src/nitro_ai_judge_cli/state.py
@@ -395,6 +395,22 @@ def update_cache(kind: str, key: str, items: list[dict[str, Any]]) -> None:
     mutate_context(update)
 
 
+def clear_cache(kind: str = "all") -> None:
+    if kind not in {"all", "contests", "tasks", "submissions"}:
+        raise ValueError(f"unknown cache bucket: {kind}")
+
+    def clear(context: dict[str, Any]) -> None:
+        cache = context.get("cache")
+        if not isinstance(cache, dict):
+            return
+        if kind == "all":
+            cache.clear()
+        else:
+            cache.pop(kind, None)
+
+    mutate_context(clear)
+
+
 def cached_items(kind: str, key: str) -> list[dict[str, Any]]:
     cache = load_context().get("cache", {})
     bucket = cache.get(kind, {}) if isinstance(cache, dict) else {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -293,6 +293,18 @@ class ParserTests(unittest.TestCase):
         args = cli.build_parser().parse_args(["download-data", "--list"])
         self.assertTrue(args.list_only)
         self.assertIsNone(args.out_dir)
+    def test_cache_and_offline_flags_are_parsed(self) -> None:
+        parser = cli.build_parser()
+        self.assertTrue(parser.parse_args(["ls", "--offline"]).offline)
+        self.assertTrue(parser.parse_args(["show", "--offline"]).offline)
+        self.assertEqual(
+            parser.parse_args(["cache", "clear"]).kind,
+            "all",
+        )
+        self.assertEqual(
+            parser.parse_args(["cache", "clear", "tasks"]).kind,
+            "tasks",
+        )
 
     def test_task_target_resolution_prefers_explicit_values_without_mutation(self) -> None:
         context = {
@@ -552,6 +564,131 @@ class ContextDispatchTests(unittest.TestCase):
                     result = cli.main(["show"])
         self.assertEqual(result, 1)
         self.assertIn("naij use", stdout.getvalue())
+
+    def test_cache_status_and_clear_preserve_selection_and_credentials(self) -> None:
+        state.save_state({"access_token": "secret"})
+        state.update_cache("contests", "featured", [])
+        state.update_cache("tasks", "org/contest", [{"id": "task"}])
+        state.update_cache("submissions", "org/contest/task", [])
+        state.set_contest({"organizationSlug": "org", "competitionSlug": "contest"})
+        state.set_task({"id": "task"})
+
+        status = invoke(cli.main, ["cache", "status"])
+        self.assertEqual(status[0], 0)
+        self.assertIn("freshness unavailable", status[1])
+        self.assertIn("contests/featured: 0 records", status[1])
+        self.assertIn("tasks/org/contest: 1 records", status[1])
+
+        self.assertEqual(invoke(cli.main, ["cache", "clear", "tasks"])[0], 0)
+        context = state.load_context()
+        self.assertEqual(state.selected_contest(context), ("org", "contest"))
+        self.assertEqual(state.selected_task(context), "task")
+        self.assertNotIn("tasks", context["cache"])
+        self.assertIn("contests", context["cache"])
+        self.assertEqual(state.load_state(), {"access_token": "secret"})
+
+        self.assertEqual(invoke(cli.main, ["cache", "clear"])[0], 0)
+        self.assertEqual(invoke(cli.main, ["cache", "clear"])[0], 0)
+        context = state.load_context()
+        self.assertEqual(context["cache"], {})
+        self.assertEqual(state.selected_task(context), "task")
+
+    def test_offline_ls_uses_cached_context_without_authentication(self) -> None:
+        contest = {
+            "organizationSlug": "org",
+            "competitionSlug": "contest",
+            "title": "Cached Contest",
+        }
+        contexts = (
+            (
+                {"cache": {"contests": {"featured": [contest]}}},
+                "Cached Contest",
+            ),
+            (
+                {
+                    "contest": contest,
+                    "cache": {"tasks": {"org/contest": [{"id": "task", "title": "Cached Task"}]}},
+                },
+                "Cached Task",
+            ),
+            (
+                {
+                    "contest": contest,
+                    "task": {"id": "task"},
+                    "cache": {
+                        "submissions": {
+                            "org/contest/task": [
+                                {"id": "submission-7", "state": "done", "partialTaskScore": 42}
+                            ]
+                        }
+                    },
+                },
+                "42 / 100",
+            ),
+        )
+        with patch.object(cli, "require_auth", side_effect=AssertionError("auth")):
+            for context, expected in contexts:
+                with self.subTest(expected=expected):
+                    state.save_context(context)
+                    result = invoke(cli.main, ["ls", "--offline"])
+                    self.assertEqual(result[0], 0)
+                    self.assertIn("[cached; freshness unavailable]", result[1])
+                    self.assertIn(expected, result[1])
+
+    def test_offline_show_uses_cached_task_and_submission_details(self) -> None:
+        contest = {"organizationSlug": "org", "competitionSlug": "contest"}
+        task_context = {
+            "contest": contest,
+            "task": {"id": "backend-task", "title": "Detailed", "statement": "Cached statement"},
+            "cache": {
+                "tasks": {
+                    "org/contest": [
+                        {"id": "other", "title": "Other"},
+                        {"id": "backend-task", "title": "Detailed"},
+                    ]
+                }
+            },
+        }
+        with patch.object(cli, "require_auth", side_effect=AssertionError("auth")):
+            state.save_context(task_context)
+            task = invoke(cli.main, ["show", "--offline"])
+            self.assertEqual(task[0], 0)
+            self.assertIn("Task number: 2", task[1])
+            self.assertIn("ID: backend-task", task[1])
+            self.assertIn("Cached statement", task[1])
+
+            submission_context = {
+                **task_context,
+                "submission": {"id": "submission-7", "verdictMessage": "Cached verdict"},
+                "cache": {
+                    **task_context["cache"],
+                    "submissions": {
+                        "org/contest/backend-task": [
+                            {"id": "submission-7", "state": "done", "partialTaskScore": 42}
+                        ]
+                    },
+                },
+            }
+            state.save_context(submission_context)
+            submission = invoke(cli.main, ["show", "--offline"])
+            self.assertEqual(submission[0], 0)
+            self.assertIn("Submission: submission-7", submission[1])
+            self.assertIn("Cached verdict", submission[1])
+
+    def test_offline_missing_or_incomplete_cache_has_refresh_guidance(self) -> None:
+        state.save_context(
+            {
+                "contest": {"organizationSlug": "org", "competitionSlug": "contest"},
+                "task": {"id": "task"},
+                "cache": {"tasks": {"org/contest": [{"id": "task"}]}},
+            }
+        )
+        with patch.object(cli, "require_auth", side_effect=AssertionError("auth")):
+            result = invoke(cli.main, ["show", "--offline"])
+
+        self.assertEqual(result[0], 1)
+        self.assertIn("incomplete", result[1])
+        self.assertIn("without --offline to refresh", result[1])
 
 
 if __name__ == "__main__":

--- a/tests/test_state_completion.py
+++ b/tests/test_state_completion.py
@@ -401,8 +401,16 @@ class CompletionTests(unittest.TestCase):
         )
         self.assertEqual(
             completion.candidates(["c"], context, interactive=True),
-            ["cd", "completion", "contests"],
+            ["cache", "cd", "completion", "contests"],
         )
+
+    def test_cache_and_offline_completion(self) -> None:
+        context = self.context()
+        self.assertEqual(completion.candidates(["cache", ""], context), ["clear", "status"])
+        self.assertEqual(
+            completion.candidates(["cache", "clear", "t"], context), ["tasks"]
+        )
+        self.assertIn("--offline", completion.candidates(["ls", "-"], context))
 
     def test_use_resolves_the_current_argument_slot(self) -> None:
         context = self.context()
@@ -672,6 +680,21 @@ class CompletionTests(unittest.TestCase):
         self.assertEqual(first, second)
         self.assertEqual(loader.call_count, 2)
         self.assertNotIn("all", state.load_context().get("cache", {}).get("contests", {}))
+
+    def test_cleared_cache_is_refetched_by_completion(self) -> None:
+        state.save_context({"cache": {"contests": {"all": []}}})
+        state.clear_cache("contests")
+        competitions = [{"organizationSlug": "ceoai", "competitionSlug": "2026"}]
+        auth_state, fresh, auth = self.auth_patches()
+        with auth_state, fresh, auth, patch.object(
+            contests, "load_competitions", return_value=competitions
+        ) as loader:
+            self.assertEqual(
+                completion.candidates(["ceo"], interactive=True), ["ceoai/2026"]
+            )
+
+        loader.assert_called_once()
+        self.assertEqual(state.cached_items("contests", "all"), competitions)
 
     def test_explicit_contest_completion_fetches_only_its_tasks(self) -> None:
         tasks = [{"id": "vision"}]


### PR DESCRIPTION
Closes #52
Closes #54

Adds cache status/selective clearing plus cached-only `ls` and `show` paths at every context depth. Offline output carries freshness labeling, missing/incomplete cache guidance, and never enters authentication or network dispatch.

This PR is stacked on #78 so clearing uses the shared cross-process locked context mutation path.

Verification: `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests` (240 passed, 2 skipped).