### PR TITLE
Harden release publishing and package licensing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Build and Publish
 
 on:
   push:
-    branches: [main, feat/play-manager]
+    branches: [main]
     tags: ["v*"]
   pull_request:
   workflow_dispatch:
@@ -85,6 +85,37 @@ jobs:
           docker run --rm --entrypoint docker naij-play-manager:ci compose version
           docker run --rm --entrypoint python naij-play-manager:ci -c "import aiohttp, nitro_ai_judge_cli.manager"
 
+  manager-arm64:
+    name: Manager ARM64 release-candidate smoke (QEMU)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Build ARM64 candidate from release inputs
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: manager/Dockerfile
+          platforms: linux/arm64
+          load: true
+          tags: naij-play-manager:arm64-ci
+      - name: Smoke Docker, Compose, Python, entrypoint, and health under QEMU
+        shell: bash
+        run: |
+          docker run --rm --platform linux/arm64 --entrypoint docker naij-play-manager:arm64-ci version
+          docker run --rm --platform linux/arm64 --entrypoint docker naij-play-manager:arm64-ci compose version
+          docker run --rm --platform linux/arm64 --entrypoint python naij-play-manager:arm64-ci -c "import aiohttp, nitro_ai_judge_cli.manager"
+          docker run -d --platform linux/arm64 --name naij-manager-arm64 -p 51123:51123 naij-play-manager:arm64-ci
+          trap 'docker logs naij-manager-arm64; docker rm -f naij-manager-arm64' EXIT
+          for attempt in {1..30}; do
+            curl --fail --silent http://127.0.0.1:51123/nitro/api/v1/health && exit 0
+            sleep 1
+          done
+          exit 1
+
   docker-integration:
     runs-on: ubuntu-latest
     needs: manager-build
@@ -104,14 +135,16 @@ jobs:
         run: python -m unittest discover -s tests/integration -v
 
   edge:
-    if: github.ref == 'refs/heads/feat/play-manager'
-    needs: [host-test, build, manager-build, docker-integration]
+    if: github.ref == 'refs/heads/main'
+    needs: [host-test, build, manager-build, manager-arm64, docker-integration]
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@v4
+      - name: Verify the configured edge source branch exists
+        run: git ls-remote --exit-code --heads origin refs/heads/main
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -129,7 +162,7 @@ jobs:
 
   manager-publish:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [host-test, build, manager-build, docker-integration]
+    needs: [host-test, build, manager-build, manager-arm64, docker-integration]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -189,3 +222,21 @@ jobs:
           name: python-package-distributions
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create the GitHub Release after all artifacts publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          NOTES="docs/release-notes-${GITHUB_REF_NAME#v}.md"
+          test -f "${NOTES}"
+          gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 || \
+            gh release create "${GITHUB_REF_NAME}" --title "Nitro AI Judge CLI ${GITHUB_REF_NAME#v}" --notes-file "${NOTES}" --latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Smoke Docker, Compose, Python, entrypoint, and health under QEMU
         shell: bash
         run: |
-          docker run --rm --platform linux/arm64 --entrypoint docker naij-play-manager:arm64-ci version
+          docker run --rm --platform linux/arm64 --entrypoint docker naij-play-manager:arm64-ci --version
           docker run --rm --platform linux/arm64 --entrypoint docker naij-play-manager:arm64-ci compose version
           docker run --rm --platform linux/arm64 --entrypoint python naij-play-manager:arm64-ci -c "import aiohttp, nitro_ai_judge_cli.manager"
           docker run -d --platform linux/arm64 --name naij-manager-arm64 -p 51123:51123 naij-play-manager:arm64-ci

--- a/LICENSES/Inter-OFL-1.1.txt
+++ b/LICENSES/Inter-OFL-1.1.txt
@@ -1,0 +1,92 @@
+Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION AND CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/LICENSES/Lexend-OFL-1.1.txt
+++ b/LICENSES/Lexend-OFL-1.1.txt
@@ -1,0 +1,93 @@
+Copyright 2018 The Lexend Project Authors (https://github.com/googlefonts/lexend), with Reserved Font Name “RevReading Lexend”.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -460,10 +460,12 @@ internally.
 The release workflow runs host tests on Linux, Windows, and macOS, builds and
 checks the CLI, builds the manager, and runs Linux Docker integration. A release
 tag must exactly match `pyproject.toml`. It refuses an existing immutable GHCR
-tag, publishes `linux/amd64` and `linux/arm64`, then updates the matching `3.0`
-and `stable` tags. PyPI publication happens only after GHCR succeeds. The
-development branch publishes `edge`; neither the workflow nor installer uses
-`latest`.
+tag, smoke-tests the ARM64 candidate under QEMU, publishes `linux/amd64` and
+`linux/arm64`, then updates the matching `3.0` and `stable` tags. PyPI
+publication happens only after GHCR succeeds, and the GitHub Release is created
+only after PyPI succeeds. Successful pushes to `main` publish `edge`; neither
+the workflow nor installer uses `latest`. Native Docker integration continues
+to cover host socket behavior; the ARM64 check covers packaging and startup.
 
 Recommended release checks:
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,8 @@
+# Third-party notices
+
+The Play manager web interface bundles these unmodified webfonts:
+
+| Files | Family | Source | License |
+| --- | --- | --- | --- |
+| `inter-latin.woff2`, `inter-latin-ext.woff2` | Inter | https://github.com/rsms/inter | SIL Open Font License 1.1; see `LICENSES/Inter-OFL-1.1.txt` |
+| `lexend-deca-latin.woff2`, `lexend-deca-latin-ext.woff2` | Lexend Deca | https://github.com/googlefonts/lexend | SIL Open Font License 1.1; see `LICENSES/Lexend-OFL-1.1.txt` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=77.0.3", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,6 +7,8 @@ name = "nitro-ai-judge-cli"
 version = "3.0.4"
 description = "CLI client for judge.nitro-ai.org"
 readme = "README.md"
+license = "MIT AND OFL-1.1"
+license-files = ["LICENSE", "LICENSES/*.txt", "THIRD_PARTY_NOTICES.md"]
 requires-python = ">=3.10"
 dependencies = ["textual>=8.2,<9"]
 authors = [


### PR DESCRIPTION
## Summary

- publish edge from current `main` only after existing checks and an ARM64 QEMU smoke
- create GitHub Releases only after GHCR and PyPI succeed
- declare PEP 639 MIT/OFL metadata and ship complete Inter/Lexend license notices
- backfilled the missing v3.0.1 and v3.0.2 GitHub Releases; v3.0.4 remains latest

## Verification

- `uv run --extra manager python -m unittest discover -s tests -v` (232 passed, 2 skipped)
- `uv build --clear`
- `uvx twine check dist/*`
- wheel/sdist metadata and license-file assertions
- Releases API reports v3.0.4 as latest
- `git diff --check`

Closes #13
Closes #15
Closes #16
Closes #38
Closes #64