### PR TITLE
feat: list available task data files

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ If saved context is missing or stale, Nitro AI Judge reports which `naij use` co
 Download one or more task-file categories with `-c`/`--category`. Supported categories are `statement`, `train_data`, `test_data`, `sample_output`, and `custom_archive`.
 
 ```bash
+naij download-data --list
 naij download-data -c statement -o TASK.md
 naij download-data -c train_data -c test_data -d data
 naij download-data -c test_data -o test_data.zip -f
@@ -194,6 +195,7 @@ naij download-data -c test_data -o test_data.zip -f
 
 Download options:
 
+- `--list`: show available canonical category keys and labels without writing files
 - `-c`, `--category`: category to download; repeat for multiple categories
 - `-d`, `--out-dir`: destination directory
 - `-o`, `--output`: destination file when downloading one category

--- a/src/nitro_ai_judge_cli/cli.py
+++ b/src/nitro_ai_judge_cli/cli.py
@@ -286,9 +286,15 @@ def build_parser() -> argparse.ArgumentParser:
     download = sub.add_parser("download-data", help="Download task data files")
     download.add_argument("targets", nargs="*", help="[competition] [task]")
     download.add_argument("-c", "--category", action="append", choices=sorted(TASK_FILE_CATEGORIES))
-    download.add_argument("-d", "--out-dir", default=".")
+    download.add_argument("-d", "--out-dir")
     download.add_argument("-o", "--output", help="Output path for one category")
     download.add_argument("-f", "--force", action="store_true", help="Overwrite files")
+    download.add_argument(
+        "--list",
+        action="store_true",
+        dest="list_only",
+        help="List available task data without downloading",
+    )
 
     add_play_parser(sub)
 
@@ -383,9 +389,10 @@ def _dispatch_authenticated(args: argparse.Namespace) -> int:
             result = cmd_download_data(
                 cookies, bearer, org, comp, task_id,
                 categories=args.category,
-                output_dir=args.out_dir,
+                output_dir=args.out_dir or ".",
                 output_path=args.output,
                 force=args.force,
+                list_only=args.list_only,
             )
         elif args.cmd == "submit":
             result = cmd_submit(
@@ -520,6 +527,20 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if args.cmd == "use":
         return _cmd_use(args)
+    if args.cmd == "download-data" and args.list_only:
+        conflicts = [
+            flag
+            for enabled, flag in (
+                (args.category, "--category"),
+                (args.out_dir is not None, "--out-dir"),
+                (args.output is not None, "--output"),
+                (args.force, "--force"),
+            )
+            if enabled
+        ]
+        if conflicts:
+            print(f"Error: --list cannot be used with {', '.join(conflicts)}")
+            return 1
     if not args.cmd:
         return run_shell(lambda words: main(words))
     if args.cmd == "login":

--- a/src/nitro_ai_judge_cli/completion.py
+++ b/src/nitro_ai_judge_cli/completion.py
@@ -38,7 +38,7 @@ OPTION_GROUPS = {
     "task": (("--help",),),
     "download-data": (
         ("-c", "--category"), ("-d", "--out-dir"), ("-o", "--output"),
-        ("-f", "--force"), ("--help",),
+        ("-f", "--force"), ("--list",), ("--help",),
     ),
     "submit": (
         ("-o", "--output"), ("-s", "--source"), ("-n", "--note"),

--- a/src/nitro_ai_judge_cli/contests.py
+++ b/src/nitro_ai_judge_cli/contests.py
@@ -748,7 +748,26 @@ def cmd_download_data(
     output_dir: str,
     output_path: str | None,
     force: bool,
+    list_only: bool = False,
 ) -> int:
+    if list_only:
+        try:
+            available = load_task_file_categories(
+                cookies, bearer, org, comp, task_id
+            )
+        except (RuntimeError, ValueError, OSError) as e:
+            print(f"Error: {e}")
+            return 1
+        if not available:
+            print("No task data files available")
+            return 0
+        for category in available:
+            label = TASK_FILE_CATEGORIES.get(category) or category.replace(
+                "_", " "
+            ).replace("-", " ").capitalize()
+            print(f"{category}\t{label}")
+        return 0
+
     try:
         results = download_task_data(
             cookies,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -146,6 +146,7 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(download.out_dir, "data")
         self.assertEqual(download.output, "statement.pdf")
         self.assertTrue(download.force)
+        self.assertFalse(download.list_only)
         self.assertEqual(submissions.author, "user")
         self.assertEqual(submissions.page, 3)
         self.assertEqual(submissions.page_size, 50)
@@ -154,6 +155,11 @@ class ParserTests(unittest.TestCase):
     def test_global_state_directory_flag_is_parsed(self) -> None:
         args = cli.build_parser().parse_args(["--state-dir", "/tmp/naij", "use"])
         self.assertEqual(args.state_dir, "/tmp/naij")
+
+    def test_download_list_flag_is_parsed(self) -> None:
+        args = cli.build_parser().parse_args(["download-data", "--list"])
+        self.assertTrue(args.list_only)
+        self.assertIsNone(args.out_dir)
 
     def test_task_target_resolution_prefers_explicit_values_without_mutation(self) -> None:
         context = {
@@ -261,6 +267,50 @@ class ContextDispatchTests(unittest.TestCase):
         command.assert_called_once_with(
             ("", ""), "token", "ceoai", "ceoai-2026-day-1", "6", display_id="3"
         )
+
+    def test_download_list_uses_saved_and_explicit_task_targets(self) -> None:
+        state.set_contest(
+            {"organizationSlug": "saved", "competitionSlug": "contest"}
+        )
+        state.set_task({"id": "saved-task"})
+        auth = ({}, ("", ""), "token")
+        with patch.object(cli, "require_auth", return_value=auth), patch.object(
+            cli, "cmd_download_data", return_value=0
+        ) as command:
+            self.assertEqual(cli.main(["download-data", "--list"]), 0)
+        self.assertEqual(
+            command.call_args.args[:5],
+            (("", ""), "token", "saved", "contest", "saved-task"),
+        )
+        self.assertTrue(command.call_args.kwargs["list_only"])
+
+        tasks = [{"id": "backend-task", "title": "Task"}]
+        with patch.object(cli, "require_auth", return_value=auth), patch.object(
+            cli, "load_tasks", return_value=tasks
+        ), patch.object(cli, "cmd_download_data", return_value=0) as command:
+            self.assertEqual(
+                cli.main(["download-data", "org/contest", "1", "--list"]), 0
+            )
+        self.assertEqual(
+            command.call_args.args[:5],
+            (("", ""), "token", "org", "contest", "backend-task"),
+        )
+
+    def test_download_list_rejects_destination_flags_before_authentication(self) -> None:
+        for flag in ("--category", "--out-dir", "--output", "--force"):
+            with self.subTest(flag=flag), patch.object(
+                cli, "require_auth", side_effect=AssertionError("auth")
+            ):
+                argv = ["download-data", "--list", flag]
+                if flag == "--category":
+                    argv.append("statement")
+                elif flag == "--out-dir":
+                    argv.append(".")
+                elif flag == "--output":
+                    argv.append("file")
+                result = invoke(cli.main, argv)
+            self.assertEqual(result[0], 1)
+            self.assertIn(flag, result[1])
 
     def test_failed_use_does_not_change_existing_selection(self) -> None:
         state.set_contest({"organizationSlug": "old", "competitionSlug": "contest"})

--- a/tests/test_contests.py
+++ b/tests/test_contests.py
@@ -432,6 +432,46 @@ class TaskFileTests(unittest.TestCase):
 
 
 class CommandExitTests(unittest.TestCase):
+    def test_download_list_discovers_categories_without_writing(self) -> None:
+        output = io.StringIO()
+        with (
+            patch.object(
+                contests,
+                "load_task_file_categories",
+                return_value=["statement", "future_category"],
+            ) as discover,
+            patch.object(
+                contests,
+                "download_task_data",
+                side_effect=AssertionError("download"),
+            ),
+            patch.object(
+                contests,
+                "write_task_file",
+                side_effect=AssertionError("write"),
+            ),
+            contextlib.redirect_stdout(output),
+        ):
+            result = contests.cmd_download_data(
+                COOKIES,
+                BEARER,
+                "org",
+                "contest",
+                "7",
+                categories=None,
+                output_dir=".",
+                output_path=None,
+                force=False,
+                list_only=True,
+            )
+
+        self.assertEqual(result, 0)
+        discover.assert_called_once_with(COOKIES, BEARER, "org", "contest", "7")
+        self.assertEqual(
+            output.getvalue().splitlines(),
+            ["statement\tStatement", "future_category\tFuture category"],
+        )
+
     def test_contest_and_task_commands_cache_successful_lists(self) -> None:
         competition = {"organizationSlug": "org", "competitionSlug": "contest", "title": "Contest"}
         task = {"id": "7", "title": "Task"}

--- a/tests/test_state_completion.py
+++ b/tests/test_state_completion.py
@@ -452,6 +452,7 @@ class CompletionTests(unittest.TestCase):
         )
         self.assertIn("-c", remaining)
         self.assertIn("--category", remaining)
+        self.assertIn("--list", remaining)
 
         values = completion.candidates(
             ["submissions", "TaskOne", "-m", "both", ""], context


### PR DESCRIPTION
Closes #57

Adds `naij download-data --list` using the existing category discovery path. It prints known and future category labels without entering download/write paths, rejects conflicting destination flags, and supports explicit or saved task targets.

Verification: `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests` (236 passed, 2 skipped).