### PR TITLE
Restore Play action overview help

### DIFF
--- a/src/nitro_ai_judge_cli/play.py
+++ b/src/nitro_ai_judge_cli/play.py
@@ -587,7 +587,7 @@ def cmd_play(args: argparse.Namespace) -> int:
 
 
 def normalize_play_argv(argv: list[str]) -> list[str]:
-    if not argv or argv[0] not in PLAY_ACTIONS:
+    if not argv or argv[0] not in (*PLAY_ACTIONS, "-h", "--help"):
         return ["play", *argv]
     return list(argv)
 
@@ -682,8 +682,16 @@ def populate_play_actions(actions: argparse._SubParsersAction) -> None:
         command.add_argument("--tls-key")
         command.add_argument("--public-url")
         command.add_argument("--yes", action="store_true", help="Approve non-interactively")
-    for name in ("status", "open", "start", "stop", "restart", "uninstall", "sync-credentials"):
-        manager_actions.add_parser(name)
+    for name, help_text in (
+        ("status", "Show manager status"),
+        ("open", "Open the manager dashboard"),
+        ("start", "Start the manager"),
+        ("stop", "Stop the manager"),
+        ("restart", "Restart the manager"),
+        ("uninstall", "Uninstall the manager"),
+        ("sync-credentials", "Synchronize saved credentials"),
+    ):
+        manager_actions.add_parser(name, help=help_text)
     purge = manager_actions.add_parser("purge", help="Remove manager-private SQLite state")
     purge.add_argument("--force", action="store_true", required=True)
 

--- a/tests/test_play.py
+++ b/tests/test_play.py
@@ -92,6 +92,7 @@ class PlayProtocolTests(unittest.TestCase):
     def test_default_action_is_play_and_manager_is_preserved(self) -> None:
         self.assertEqual(play.normalize_play_argv([]), ["play"])
         self.assertEqual(play.normalize_play_argv(["org/contest"]), ["play", "org/contest"])
+        self.assertEqual(play.normalize_play_argv(["--help"]), ["--help"])
         self.assertEqual(play.normalize_play_argv(["manager", "status"]), ["manager", "status"])
 
 
@@ -416,6 +417,32 @@ class PlayCommandTests(unittest.TestCase):
             parser.parse_args(["play", "--help"])
         self.assertEqual(shown.exception.code, 0)
         self.assertIn("cancel", help_output.getvalue())
+
+    def test_play_help_routes_and_manager_descriptions(self) -> None:
+        def show_help(argv: list[str]) -> str:
+            output = io.StringIO()
+            with redirect_stdout(output), self.assertRaises(SystemExit) as shown:
+                cli.main(argv)
+            self.assertEqual(shown.exception.code, 0)
+            return output.getvalue()
+
+        overview = show_help(["play", "--help"])
+        action = show_help(["play", "play", "--help"])
+        manager = show_help(["play", "manager", "--help"])
+
+        self.assertEqual(overview.splitlines()[0], "usage: naij play [-h] ACTION ...")
+        self.assertTrue(action.startswith("usage: naij play play [-h]"))
+        self.assertEqual(manager.splitlines()[0], "usage: naij play manager [-h] ACTION ...")
+        for description in (
+            "Show manager status",
+            "Open the manager dashboard",
+            "Start the manager",
+            "Stop the manager",
+            "Restart the manager",
+            "Uninstall the manager",
+            "Synchronize saved credentials",
+        ):
+            self.assertIn(description, manager)
 
     def test_cancel_defaults_to_selected_contest(self) -> None:
         context = {


### PR DESCRIPTION
## Summary

- keep `naij play --help` on the Play action overview while preserving the bare default action
- describe every registered manager action in `naij play manager --help`
- cover overview, default-action, and manager help routing

## Verification

- `uv run --extra manager python -m unittest discover -s tests` (233 passed, 2 skipped)
- `git diff --check`

Closes #37