### PR TITLE
fix: keep managed Jupyter usable after restarts

### DIFF
--- a/src/nitro_ai_judge_cli/manager/app.py
+++ b/src/nitro_ai_judge_cli/manager/app.py
@@ -131,23 +131,18 @@ async def security_middleware(request: web.Request, handler: Any) -> web.StreamR
         else:
             session_id = request.cookies.get(SESSION_COOKIE, "")
             session = _browser_session(app, session_id)
-            if not session:
-                direct_loopback_open = (
-                    not app["lan"]
-                    and request.method == "GET"
-                    and path.startswith(f"{BASE_PATH}/competitions/")
-                    and request.headers.get("Upgrade", "").lower() != "websocket"
+            local_competition = not app["lan"] and path.startswith(
+                f"{BASE_PATH}/competitions/"
+            )
+            if not session and not local_competition:
+                raise WireError(
+                    ErrorType.AUTHENTICATION_REQUIRED.value,
+                    "Play manager authentication required",
+                    status=401,
                 )
-                if not direct_loopback_open:
-                    raise WireError(
-                        ErrorType.AUTHENTICATION_REQUIRED.value,
-                        "Play manager authentication required",
-                        status=401,
-                    )
-                session_id, session = _new_session(app)
-                request["new_session_id"] = session_id
             request["auth_kind"] = "browser"
-            request["browser_session"] = session
+            if session:
+                request["browser_session"] = session
             browser_mutation = request.method not in {"GET", "HEAD", "OPTIONS"}
             browser_websocket = request.headers.get("Upgrade", "").lower() == "websocket"
             if browser_mutation or browser_websocket:
@@ -176,17 +171,6 @@ async def security_middleware(request: web.Request, handler: Any) -> web.StreamR
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["Referrer-Policy"] = "no-referrer"
-    new_session_id = request.get("new_session_id")
-    if new_session_id:
-        response.set_cookie(
-            SESSION_COOKIE,
-            new_session_id,
-            httponly=True,
-            secure=app["public_origin"].startswith("https://"),
-            samesite="Strict",
-            path=f"{BASE_PATH}/",
-            max_age=12 * 3600,
-        )
     return response
 
 

--- a/src/nitro_ai_judge_cli/manager/backend.py
+++ b/src/nitro_ai_judge_cli/manager/backend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import os
 import re
@@ -28,6 +29,7 @@ Progress = Callable[[str, str], Awaitable[None]]
 DockerEvent = Callable[[dict[str, Any]], Awaitable[None]]
 LABEL_PREFIX = "org.nitro-ai.naij.play"
 SHARED_NETWORK = "naij-play"
+JUPYTER_CONFIG_DIR = "/etc/naij-jupyter"
 PULL_PROGRESS_INTERVAL = 1
 # Nitro publishes no designated default; its generic test pair matches a real contest pair.
 V3_0_2_FALLBACK_IMAGES = (
@@ -508,9 +510,10 @@ class DockerBackend:
             "command": [base_path],
             "volumes": [
                 f"{workspace_name}:/home/jovyan",
-                f"{names['config']}:/home/jovyan/.jupyter:ro",
+                f"{names['config']}:{JUPYTER_CONFIG_DIR}:ro",
             ],
             "environment": {
+                "JUPYTER_CONFIG_PATH": JUPYTER_CONFIG_DIR,
                 "PROXY_URL": "http://submission-proxy:9000",
                 "NITRO_SUBMISSION_PROXY_URL": "http://submission-proxy:9000",
                 "PROXY_URL_CLIENT": proxy_path,
@@ -574,6 +577,24 @@ class DockerBackend:
                 names["config"]: {"external": True, "name": names["config"]},
             },
         }
+
+    def _migrate_jupyter_config_mount(
+        self, org: str, competition: str
+    ) -> dict[str, Any] | None:
+        path = self.compose_path(org, competition)
+        with open(path, encoding="utf-8") as stream:
+            compose = json.load(stream)
+        notebook = compose["services"]["jupyter-server"]
+        old_mount = f"{self.names(org, competition)['config']}:/home/jovyan/.jupyter:ro"
+        if old_mount not in notebook["volumes"]:
+            return None
+        original = copy.deepcopy(compose)
+        notebook["volumes"][notebook["volumes"].index(old_mount)] = (
+            f"{self.names(org, competition)['config']}:{JUPYTER_CONFIG_DIR}:ro"
+        )
+        notebook["environment"]["JUPYTER_CONFIG_PATH"] = JUPYTER_CONFIG_DIR
+        self._atomic_compose(path, compose)
+        return original
 
     async def _prepare_legacy(
         self,
@@ -1184,7 +1205,22 @@ class DockerBackend:
             )
         if action in {"start", "stop", "restart"}:
             await progress("applying", f"{action.capitalize()}ing competition services")
-            await self.run(self.compose_command(org, competition, action), timeout=180)
+            original_compose = (
+                self._migrate_jupyter_config_mount(org, competition)
+                if action != "stop"
+                else None
+            )
+            command = (
+                self.compose_command(org, competition, "up", "-d", "--force-recreate")
+                if original_compose is not None
+                else self.compose_command(org, competition, action)
+            )
+            try:
+                await self.run(command, timeout=180)
+            except (Exception, asyncio.CancelledError):
+                if original_compose is not None:
+                    self._atomic_compose(compose_path, original_compose)
+                raise
             if action in {"start", "restart"}:
                 await progress("verifying", "Checking Jupyter and submission proxy routes")
                 await self._wait_services_with_proxy_fallback(

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -15,6 +15,7 @@ except ImportError:  # pragma: no cover - host-only installs intentionally omit 
 
 if web is not None:
     from nitro_ai_judge_cli.manager.app import (
+        SESSION_COOKIE,
         _competition_sort_key,
         _docker_event_competitions,
         _new_session,
@@ -146,6 +147,18 @@ class ManagerBackendModelTests(unittest.TestCase):
         self.assertEqual(
             notebook["environment"]["PROXY_URL_CLIENT"],
             "/nitro/competitions/org/contest/proxy/",
+        )
+        self.assertEqual(
+            notebook["environment"]["JUPYTER_CONFIG_PATH"],
+            "/etc/naij-jupyter",
+        )
+        self.assertIn(
+            "naij-play-org-contest-jupyter-config:/etc/naij-jupyter:ro",
+            notebook["volumes"],
+        )
+        self.assertNotIn(
+            "naij-play-org-contest-jupyter-config:/home/jovyan/.jupyter:ro",
+            notebook["volumes"],
         )
         self.assertEqual(
             notebook["command"], ["/nitro/competitions/org/contest/jupyter/"]
@@ -338,6 +351,57 @@ class ManagerBackendSafetyTests(unittest.IsolatedAsyncioTestCase):
             )
         self.backend._rollback_legacy.assert_awaited_once_with(
             "org", "contest", context
+        )
+    async def test_start_retries_read_only_jupyter_home_mount_migration(self) -> None:
+        compose = self.backend._compose(
+            "org", "contest", gpu=False, pull_policy="never"
+        )
+        notebook = compose["services"]["jupyter-server"]
+        notebook["volumes"][1] = (
+            "naij-play-org-contest-jupyter-config:/home/jovyan/.jupyter:ro"
+        )
+        notebook["environment"].pop("JUPYTER_CONFIG_PATH")
+        self.backend._atomic_compose(
+            self.backend.compose_path("org", "contest"), compose
+        )
+        self.backend.run = AsyncMock(
+            side_effect=WireError("operation_failed", "compose failed")
+        )
+        self.backend._wait_services_with_proxy_fallback = AsyncMock()
+        self.backend.inspect_competition = AsyncMock(return_value={})
+
+        with self.assertRaisesRegex(WireError, "compose failed"):
+            await self.backend.perform("org", "contest", "start", {}, AsyncMock())
+        with open(
+            self.backend.compose_path("org", "contest"), encoding="utf-8"
+        ) as stream:
+            failed_notebook = json.load(stream)["services"]["jupyter-server"]
+        self.assertNotIn("JUPYTER_CONFIG_PATH", failed_notebook["environment"])
+        self.assertIn(
+            "naij-play-org-contest-jupyter-config:/home/jovyan/.jupyter:ro",
+            failed_notebook["volumes"],
+        )
+
+        self.backend.run = AsyncMock(return_value=(0, "", ""))
+        await self.backend.perform("org", "contest", "start", {}, AsyncMock())
+
+        with open(
+            self.backend.compose_path("org", "contest"), encoding="utf-8"
+        ) as stream:
+            notebook = json.load(stream)["services"]["jupyter-server"]
+        self.assertEqual(
+            notebook["environment"]["JUPYTER_CONFIG_PATH"],
+            "/etc/naij-jupyter",
+        )
+        self.assertIn(
+            "naij-play-org-contest-jupyter-config:/etc/naij-jupyter:ro",
+            notebook["volumes"],
+        )
+        self.backend.run.assert_awaited_once_with(
+            self.backend.compose_command(
+                "org", "contest", "up", "-d", "--force-recreate"
+            ),
+            timeout=180,
         )
 
     async def test_ready_is_workspace_only_and_stopped_requires_containers(self) -> None:
@@ -1670,6 +1734,11 @@ class ManagerRouteTests(unittest.IsolatedAsyncioTestCase):
         await lan.start_server()
         try:
             headers = {"Host": "play.example:51123"}
+            competition = await lan.post(
+                "/nitro/competitions/org/contest/jupyter/api/sessions",
+                headers={**headers, "Origin": "https://play.example:51123"},
+            )
+            self.assertEqual(competition.status, 401)
             page = await lan.get("/nitro/", headers=headers)
             self.assertIn("Protected network dashboard", await page.text())
             denied = await lan.post(
@@ -1791,6 +1860,7 @@ class ManagerProxyTests(unittest.IsolatedAsyncioTestCase):
             public_url="http://localhost:51123",
             lan=False,
         )
+        self.app = app
         self.client = TestClient(TestServer(app))
         await self.client.start_server()
         self.headers = {"Host": "localhost:51123", "Authorization": "Bearer secret"}
@@ -1881,6 +1951,30 @@ class ManagerProxyTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(value["csrf"])
         self.assertEqual(value["cookie"], "competition=safe")
         await socket.close()
+
+    async def test_local_jupyter_post_survives_manager_session_restart(self) -> None:
+        stale, _ = _new_session(self.app)
+        self.app["sessions"].clear()
+        response = await self.client.post(
+            "/nitro/competitions/org/contest/jupyter/api/sessions",
+            headers={
+                "Host": "localhost:51123",
+                "Origin": "http://localhost:51123",
+                "Cookie": f"{SESSION_COOKIE}={stale}",
+            },
+        )
+        self.assertEqual(response.status, 200)
+        self.assertIsNone((await response.json())["cookie"])
+
+        denied = await self.client.post(
+            "/nitro/competitions/org/contest/jupyter/api/sessions",
+            headers={
+                "Host": "localhost:51123",
+                "Origin": "https://attacker.example",
+                "Cookie": f"{SESSION_COOKIE}={stale}",
+            },
+        )
+        self.assertEqual(denied.status, 403)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- keep local Jupyter proxy traffic working when a Play manager restart clears in-memory dashboard sessions, while retaining same-origin checks for mutations/WebSockets and LAN authentication
- keep Jupyter's generated server config read-only at `/etc/naij-jupyter` without masking the writable `~/.jupyter` settings/workspaces tree
- migrate existing saved Compose files on their next start/restart, force one recreation without removing the workspace volume, and restore the old Compose file if recreation fails

## Verification

- `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests` — 234 passed, 2 skipped
- rebuilt and reinstalled `naij-play-manager:dev`; manager is healthy
- recreated `nitro/rise-2026-final`, then exercised legacy-mount migration through `naij play restart`
- verified the notebook now mounts its config at `/etc/naij-jupyter:ro`, loads it through `JUPYTER_CONFIG_PATH`, and `jovyan` can write under `~/.jupyter/lab/user-settings`
- restarted the manager and confirmed a same-origin Jupyter POST reaches Jupyter instead of returning the manager's stale-session 401
