### PR TITLE
Release 3.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ python3 -m twine check dist/*
 docker build -f manager/Dockerfile -t naij-play-manager:dev .
 NAIJ_DOCKER_INTEGRATION=1 NAIJ_PLAY_MANAGER_IMAGE=naij-play-manager:dev \
   python3 -m unittest discover -s tests/integration -v
-git tag v3.1.3
+git tag v3.1.4
 git push origin main --tags
 ```
 

--- a/docs/release-notes-3.1.4.md
+++ b/docs/release-notes-3.1.4.md
@@ -1,0 +1,5 @@
+# Nitro AI Judge CLI 3.1.4
+
+3.1.4 makes Play manager workspace-volume deletion require an exact typed competition reference before the Delete volume button becomes available.
+
+Pressing Enter with an incomplete or incorrect reference now does nothing; with an exact match it follows the same deletion path as the enabled Delete volume button. Cancel remains non-destructive.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nitro-ai-judge-cli"
-version = "3.1.3"
+version = "3.1.4"
 description = "CLI client for judge.nitro-ai.org"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/nitro_ai_judge_cli/manager/assets/app.js
+++ b/src/nitro_ai_judge_cli/manager/assets/app.js
@@ -29,6 +29,7 @@
   const paginations = [...document.querySelectorAll("[data-pagination]")];
   const dialog = document.querySelector("#delete-dialog");
   const confirmation = document.querySelector("#delete-confirmation");
+  const deleteConfirm = document.querySelector("#delete-confirm");
   const removeImageDialog = document.querySelector("#remove-image-dialog");
   const removeContainerDialog = document.querySelector("#remove-container-dialog");
   const loginDialog = document.querySelector("#nitro-login-dialog");
@@ -545,6 +546,7 @@
         state.deleteRef = reference;
         document.querySelector("#delete-reference").textContent = reference;
         confirmation.value = "";
+        deleteConfirm.disabled = true;
         document.querySelector("#delete-error").textContent = "";
         dialog.showModal();
         confirmation.focus();
@@ -560,6 +562,18 @@
       showAlert(error.message, action === "copy-link" ? () => copyJupyterLink(button, reference) : () => startAction(reference, action));
     } finally {
       button.disabled = false;
+    }
+  });
+
+  confirmation.addEventListener("input", () => {
+    deleteConfirm.disabled = confirmation.value !== state.deleteRef;
+  });
+
+  confirmation.addEventListener("keydown", event => {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    if (!deleteConfirm.disabled) {
+      document.querySelector("#delete-form").requestSubmit(deleteConfirm);
     }
   });
 

--- a/src/nitro_ai_judge_cli/manager/assets/index.html
+++ b/src/nitro_ai_judge_cli/manager/assets/index.html
@@ -137,7 +137,7 @@
       <p>This permanently removes the private workspace volume. Images remain available.</p>
       <label><span>Type <strong id="delete-reference"></strong> to confirm</span><input id="delete-confirmation" autocomplete="off"></label>
       <p class="dialog-error" id="delete-error" aria-live="polite"></p>
-      <div class="dialog-actions"><button value="cancel" class="quiet-button">Cancel</button><button value="confirm" class="danger-button">Delete volume</button></div>
+      <div class="dialog-actions"><button value="cancel" class="quiet-button">Cancel</button><button id="delete-confirm" value="confirm" class="danger-button" disabled>Delete volume</button></div>
     </form>
   </dialog>
 

--- a/src/nitro_ai_judge_cli/play_protocol.py
+++ b/src/nitro_ai_judge_cli/play_protocol.py
@@ -10,12 +10,12 @@ from typing import Any
 
 API_VERSION = 1
 MANAGER_IDENTITY = "naij-play-manager"
-MANAGER_VERSION = "3.1.3"
+MANAGER_VERSION = "3.1.4"
 MINIMUM_CLI_VERSION = "3.0.0"
 DEFAULT_MANAGER_BIND = "127.0.0.1"
 DEFAULT_MANAGER_PORT = 51123
 DEFAULT_MANAGER_IMAGE = (
-    "ghcr.io/mihneateodorstoica/naij-play-manager:3.1.3"
+    "ghcr.io/mihneateodorstoica/naij-play-manager:3.1.4"
 )
 BASE_PATH = "/nitro"
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1588,6 +1588,14 @@ class ManagerRouteTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn(
             'actionButton("Delete volume", "delete-menu", "danger")', script
         )
+        self.assertIn('confirmation.addEventListener("input"', script)
+        self.assertIn(
+            "deleteConfirm.disabled = confirmation.value !== state.deleteRef", script
+        )
+        self.assertIn(
+            'if (event.key !== "Enter") return;\n    event.preventDefault();\n    if (!deleteConfirm.disabled) {\n      document.querySelector("#delete-form").requestSubmit(deleteConfirm);',
+            script,
+        )
         self.assertIn("removeImageDialog.showModal()", script)
         self.assertIn('new EventSource("/nitro/api/v1/events")', script)
         self.assertIn('load({ cached: true, silent: true })', script)
@@ -1677,7 +1685,7 @@ class ManagerRouteTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn('id="live-alert"', html)
         self.assertIn('id="remove-image-confirm">Remove images', html)
         self.assertIn("<h2>Delete volume?</h2>", html)
-        self.assertIn('class="danger-button">Delete volume</button>', html)
+        self.assertIn('id="delete-confirm" value="confirm" class="danger-button" disabled>Delete volume</button>', html)
         self.assertIn('id="remove-container-dialog"', html)
         self.assertIn('id="remove-container-confirm">Yes, delete container', html)
         self.assertIn('autofocus>Cancel', html)

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -19,13 +19,13 @@ from nitro_ai_judge_cli.play_protocol import (
 
 
 class ReleaseTests(unittest.TestCase):
-    def test_3_1_3_versions_keep_protocol_compatibility(self) -> None:
+    def test_3_1_4_versions_keep_protocol_compatibility(self) -> None:
         pyproject = Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
-        self.assertIn('version = "3.1.3"', pyproject)
-        self.assertEqual(MANAGER_VERSION, "3.1.3")
+        self.assertIn('version = "3.1.4"', pyproject)
+        self.assertEqual(MANAGER_VERSION, "3.1.4")
         self.assertEqual(
             DEFAULT_MANAGER_IMAGE,
-            "ghcr.io/mihneateodorstoica/naij-play-manager:3.1.3",
+            "ghcr.io/mihneateodorstoica/naij-play-manager:3.1.4",
         )
         self.assertEqual(API_VERSION, 1)
         self.assertEqual(MINIMUM_CLI_VERSION, "3.0.0")
@@ -117,7 +117,7 @@ class ReleaseTests(unittest.TestCase):
                     patch.object(
                         play,
                         "install_manager",
-                        return_value={"manager_version": "3.1.3"},
+                        return_value={"manager_version": "3.1.4"},
                     ) as install,
                     patch("builtins.print"),
                 ):

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "nitro-ai-judge-cli"
-version = "3.1.3"
+version = "3.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "textual" },


### PR DESCRIPTION
## Summary
- require an exact typed competition reference before dashboard volume deletion is enabled
- make Enter submit only the valid volume-deletion confirmation
- bump CLI and manager metadata to 3.1.4 and add release notes

## Verification
- `uv lock --check`
- `uv run --extra manager python3 -m unittest discover -s tests -p 'test_release.py' -v`
- browser smoke test covering invalid Enter, Cancel, and the intercepted delete-workspace POST