### PR TITLE
Fix submission detail keyboard scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ The complete keymap is:
 - Enter: open
 - `h`/`l` or Left/Right: move across browser panes and task views
 - Esc: back
-- Tab/Shift-Tab: cycle panes, or move between form fields
+- Tab/Shift-Tab: cycle panes, move between form fields, and in Submissions toggle
+  between the submission list and the detail scroller
 - `/`: filter the active contest, task, or submission list
 - `r`: refresh the active view
 - `?`: contextual help

--- a/src/nitro_ai_judge_cli/tui.py
+++ b/src/nitro_ai_judge_cli/tui.py
@@ -174,6 +174,13 @@ def submission_details(submission: dict[str, Any]) -> str:
             if subtask.get("metricName"):
                 line += f" · {subtask['metricName']}"
             lines.append(line)
+    lines.extend(
+        (
+            "",
+            "Tab/Shift-Tab: toggle the list and detail scroller",
+            "j/k or Up/Down: scroll the detail",
+        )
+    )
     return "\n".join(str(line) for line in lines)
 
 
@@ -1109,6 +1116,7 @@ class NitroTUI(App[int]):
         self.current_contest: dict[str, Any] | None = None
         self.current_task: dict[str, Any] | None = None
         self.current_submission: dict[str, Any] | None = None
+        self.submission_focus = "list"
         self.active_pane = "contests"
         self.active_view = 1
         self.layout_mode = "wide"
@@ -1312,6 +1320,7 @@ class NitroTUI(App[int]):
         self.current_submission = None
         self.submissions = []
         self.visible_submissions = []
+        self.submission_focus = "list"
         self.query_one("#submission-detail", Static).update("Select a submission.")
 
     def _clear_task_context(self) -> None:
@@ -2129,6 +2138,9 @@ class NitroTUI(App[int]):
         if isinstance(self.screen, ModalScreen):
             self.screen.focus_next()
             return
+        if self.active_pane == "right" and self.active_view == 3:
+            self._toggle_submission_focus()
+            return
         panes = ("contests", "tasks", "right")
         self.active_pane = panes[(panes.index(self.active_pane) + 1) % len(panes)]
         if (
@@ -2144,11 +2156,34 @@ class NitroTUI(App[int]):
         if isinstance(self.screen, ModalScreen):
             self.screen.focus_previous()
             return
+        if self.active_pane == "right" and self.active_view == 3:
+            self._toggle_submission_focus()
+            return
         panes = ("contests", "tasks", "right")
         self.active_pane = panes[(panes.index(self.active_pane) - 1) % len(panes)]
+        if (
+            self.active_pane == "right"
+            and self.active_view == 1
+            and self.current_task
+        ):
+            self._render_task_overview(self.current_task)
         self._apply_layout(self.size.width, self.size.height)
         self._focus_active()
 
+
+    def _focus_submission_list(self) -> None:
+        self.submission_focus = "list"
+        self.query_one("#submission-list", ListView).focus()
+
+    def _focus_submission_detail(self) -> None:
+        self.submission_focus = "detail"
+        self.query_one("#submission-detail-scroll", VerticalScroll).focus()
+
+    def _toggle_submission_focus(self) -> None:
+        if self.submission_focus == "detail":
+            self._focus_submission_list()
+        else:
+            self._focus_submission_detail()
     def _focus_active(self) -> None:
         if self.layout_mode == "too-small":
             return
@@ -2157,7 +2192,10 @@ class NitroTUI(App[int]):
         elif self.active_pane == "tasks":
             self.query_one("#task-list", ListView).focus()
         elif self.active_view == 3:
-            self.query_one("#submission-list", ListView).focus()
+            if self.submission_focus == "detail" and self.current_submission is not None:
+                self._focus_submission_detail()
+            else:
+                self._focus_submission_list()
         else:
             self.query_one(
                 f"#view-{('overview', 'data', 'submissions', 'play')[self.active_view - 1]}"

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -877,6 +877,77 @@ class TUIPilotTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(authors, ["tester", "tester"])
 
+    async def test_submission_detail_scrolls_by_keyboard(self) -> None:
+        self.cache_selection()
+        submission = {
+            "id": "detail-submission",
+            "username": "tester",
+            "state": "finished",
+            "verdictMessage": "Accepted",
+            "subtasks": [
+                {"maximumScore": 1, "metricName": f"Metric {index}"}
+                for index in range(50)
+            ],
+        }
+        detailed = {
+            **submission,
+            "partialSubtaskScores": [1 for _ in range(50)],
+        }
+
+        def load_for_user(
+            _cookies: tuple[str, str],
+            _bearer: str,
+            _org: str,
+            _comp: str,
+            _task_id: str,
+            *,
+            author: str | None,
+            page: int | None,
+            page_size: int,
+            mode: str,
+        ) -> tuple[list[dict], int]:
+            return ([submission], 1) if mode == "partial" else ([], 1)
+
+        with (
+            self.auth_patches(contests=[CONTEST], tasks=TASKS),
+            patch.object(tui, "load_submissions", side_effect=load_for_user),
+            patch.object(tui, "load_submission", return_value=detailed),
+        ):
+            app = tui.NitroTUI()
+            async with app.run_test(size=(110, 32)) as pilot:
+                await pilot.pause(0.2)
+                await pilot.press("3")
+                await pilot.pause(0.2)
+                await pilot.press("enter")
+                await pilot.pause(0.2)
+                self.assertEqual(app.current_submission["id"], "detail-submission")
+                self.assertEqual(app.focused.id, "submission-list")
+
+                await pilot.press("tab")
+                await pilot.pause(0.1)
+                self.assertEqual(app.focused.id, "submission-detail-scroll")
+
+                detail = app.query_one("#submission-detail-scroll")
+                await pilot.press("down")
+                await pilot.pause(0.05)
+                self.assertGreater(detail.scroll_y, 0)
+
+                await pilot.press(*(["j"] * 80))
+                await pilot.pause(0.1)
+                self.assertEqual(detail.scroll_y, detail.max_scroll_y)
+
+                await pilot.press("up")
+                await pilot.pause(0.05)
+                self.assertLess(detail.scroll_y, detail.max_scroll_y)
+
+                await pilot.press(*(["k"] * 80))
+                await pilot.pause(0.1)
+                self.assertEqual(detail.scroll_y, 0)
+
+                await pilot.press("shift+tab")
+                await pilot.pause(0.1)
+                self.assertEqual(app.focused.id, "submission-list")
+
     async def test_every_play_action_and_down_confirmation_use_keys(self) -> None:
         state.update_cache("contests", "all", [CONTEST])
         state.set_contest(CONTEST)


### PR DESCRIPTION
Fixes issue #39.

- Keep Submission detail focus separate from the list.
- Toggle between the list and detail scroller with Tab/Shift-Tab.
- Let j/k and Up/Down scroll the detail pane.
- Add a keyboard regression test plus README guidance.

Verification:
- python -m pytest tests/test_tui.py -k "submission_detail_scrolls_by_keyboard or submissions_view_is_user_only_and_has_new_button or long_task_statement_scrolls_in_the_right_pane" -q