### PR TITLE
Release 3.1.5: add Podman compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Selections are shared with the regular `naij` shell and commands.
 ## 3.0 highlights
 
 - `naij tui` provides a keyboard-first, full-screen contest cockpit.
-- `naij play manager install` starts the local Docker-backed Play manager; its
-  dashboard updates live when NAIJ or Docker changes a managed competition.
+- `naij play manager install` starts the local container-backed Play manager; its
+  dashboard updates live when NAIJ or the container runtime changes a managed competition.
 - The manager keeps Play services private behind stable Jupyter and submission
   proxy routes, with operation progress, redacted logs, cancellation, and
   offline recovery instructions.
@@ -30,7 +30,8 @@ Selections are shared with the regular `naij` shell and commands.
 
 - Python 3.10+
 - Textual 8.2.x (installed automatically)
-- A local Linux-container Docker daemon with the Compose plugin for `naij play`
+- Podman with Compose (preferred when installed), or a local Linux-container
+  Docker daemon with the Compose plugin, for `naij play`
 
 ## Installation
 
@@ -294,7 +295,8 @@ Lifecycle behavior:
 
 - `play`, `pull`, `start`, `stop`, `restart`, and `recreate` are idempotent,
   asynchronous manager operations. Identical concurrent requests share one
-  operation; conflicting requests report `competition_busy`.
+  operation; conflicting requests report `competition_busy`. Image pulls have
+  no fixed deadline; `--wait-timeout` bounds service startup after a pull.
 - Explicit `stop` remains stopped until the user starts or recreates it.
 - `delete-container` removes containers and the private project network but
   preserves `/home/jovyan`.
@@ -498,7 +500,7 @@ python3 -m twine check dist/*
 docker build -f manager/Dockerfile -t naij-play-manager:dev .
 NAIJ_DOCKER_INTEGRATION=1 NAIJ_PLAY_MANAGER_IMAGE=naij-play-manager:dev \
   python3 -m unittest discover -s tests/integration -v
-git tag v3.1.4
+git tag v3.1.5
 git push origin main --tags
 ```
 

--- a/docs/play-manager.md
+++ b/docs/play-manager.md
@@ -2,11 +2,14 @@
 
 ## Boundary
 
-NAIJ 3.0 has one host-side Docker boundary: installing, updating, starting, or
-uninstalling the manager container. Competition commands and the Textual TUI
-call the authenticated manager API and never invoke Docker for competition
-state. The manager mounts the selected local daemon socket and includes the
-Docker CLI plus Compose plugin. It is not Docker-in-Docker.
+NAIJ has one host-side container-runtime boundary: installing, updating,
+starting, or uninstalling the manager container. It prefers a working local
+Podman installation and falls back to Docker; an existing installation retains
+its saved runtime. Competition commands and the Textual TUI call the
+authenticated manager API and never invoke a host runtime for competition
+state. The manager mounts the selected local API socket and includes the Docker
+CLI plus Compose plugin, which also speaks Podman's Docker-compatible API. It
+is not Docker-in-Docker.
 
 The default endpoint is `http://localhost:51123/nitro/`. Jupyter and the
 submission proxy retain internal ports 8888 and 9000 but are not published.
@@ -34,7 +37,7 @@ NAIJ state root):
 Operational metadata, normalized Nitro credentials, adoption records,
 operation events, and competition snapshots live transactionally in SQLite in
 the private `naij-play-manager-state` volume. Manager restarts mark incomplete
-operations interrupted, then reconstruct runtime truth from live Docker labels.
+operations interrupted, then reconstruct runtime truth from live container labels.
 An explicit user stop is persisted and never auto-started.
 
 ## Runtime objects and ownership
@@ -46,7 +49,7 @@ Every new container, network, and volume has
 `org.nitro-ai.naij.play.*` labels for owner, competition identity, role,
 schema, API, and workspace. Destructive operations verify those labels first.
 A verified adoption record is the sole exception for a legacy unlabeled
-workspace volume, because Docker cannot add labels to an existing volume.
+workspace volume, because container runtimes cannot add labels to an existing volume.
 
 Compose files are generated and submitted with argument arrays. User values
 never enter shell command strings. The fixed volume-population helper receives
@@ -101,11 +104,12 @@ invalid dashboard tokens return the token login page with a visible error.
 
 ## Installation, update, and recovery
 
-Installation validates the active Docker context and Linux-container mode,
-rejects remote SSH/TCP endpoints, checks the selected port's identity, pulls
-only a missing image, writes configuration atomically, starts the manager,
-waits for health, verifies identity/API/minimum CLI compatibility, synchronizes
-credentials, and submits read-only legacy discovery.
+Installation checks Podman first and Docker second, validates local API-socket
+and Linux-container mode, rejects remote SSH/TCP endpoints, checks the selected
+port's identity, pulls only a missing image without a fixed pull deadline,
+writes configuration atomically, starts the manager, waits for health, verifies
+identity/API/minimum CLI compatibility, synchronizes credentials, and submits
+read-only legacy discovery.
 
 An update saves the prior image and Compose bytes. If the replacement is not
 healthy, it restores and starts the prior configuration. Uninstall runs Compose

--- a/docs/release-notes-3.1.5.md
+++ b/docs/release-notes-3.1.5.md
@@ -1,0 +1,7 @@
+# Nitro AI Judge CLI 3.1.5
+
+3.1.5 adds Podman compatibility to Play manager installation and lifecycle commands. NAIJ now prefers a working local Podman installation with Compose and falls back to Docker when Podman is unavailable or unusable. Existing Docker installations continue to use their saved runtime.
+
+Manager and competition image pulls no longer have arbitrary process or client-side deadlines. `--wait-timeout` continues to bound service readiness after images have been pulled, and interrupted pulls remain cancellable.
+
+The default manager image is `ghcr.io/mihneateodorstoica/naij-play-manager:3.1.5`. Manager API v1 and the minimum compatible CLI version of 3.0.0 are unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nitro-ai-judge-cli"
-version = "3.1.4"
+version = "3.1.5"
 description = "CLI client for judge.nitro-ai.org"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/nitro_ai_judge_cli/manager/backend.py
+++ b/src/nitro_ai_judge_cli/manager/backend.py
@@ -82,7 +82,7 @@ class DockerBackend:
         *,
         check: bool = True,
         input_bytes: bytes | None = None,
-        timeout: float = 300,
+        timeout: float | None = 300,
     ) -> tuple[int, str, str]:
         process = await asyncio.create_subprocess_exec(
             *command,
@@ -91,8 +91,11 @@ class DockerBackend:
             stderr=asyncio.subprocess.PIPE,
         )
         try:
-            stdout, stderr = await asyncio.wait_for(
-                process.communicate(input_bytes), timeout=timeout
+            communication = process.communicate(input_bytes)
+            stdout, stderr = (
+                await communication
+                if timeout is None
+                else await asyncio.wait_for(communication, timeout=timeout)
             )
         except asyncio.CancelledError:
             if process.returncode is None:
@@ -114,7 +117,7 @@ class DockerBackend:
             await process.wait()
             raise WireError(
                 ErrorType.DOCKER_UNAVAILABLE.value,
-                f"Docker command timed out after {int(timeout)} seconds",
+                f"Docker command timed out after {int(timeout or 0)} seconds",
                 stage="applying",
                 status=504,
             )
@@ -809,7 +812,7 @@ class DockerBackend:
                 pass
 
     async def _pull_image(self, image: str, message: str, progress: Progress) -> None:
-        task = asyncio.create_task(self.run(["docker", "pull", image], timeout=1800))
+        task = asyncio.create_task(self.run(["docker", "pull", image], timeout=None))
         started = time.monotonic()
         try:
             while True:

--- a/src/nitro_ai_judge_cli/play.py
+++ b/src/nitro_ai_judge_cli/play.py
@@ -179,7 +179,7 @@ def perform_play_action(
     client: ManagerClient | None = None,
     quiet: bool = False,
     yes: bool = False,
-    timeout: int = 600,
+    timeout: float | None = 600,
     **options: Any,
 ) -> dict[str, Any]:
     client = client or _client(yes=yes)
@@ -301,7 +301,7 @@ def cmd_play_up(
         client=client,
         quiet=quiet,
         yes=yes,
-        timeout=wait_timeout + 240,
+        timeout=None,
         gpu=gpu,
         pull=pull,
         wait_timeout=wait_timeout,
@@ -564,7 +564,11 @@ def cmd_play(args: argparse.Namespace) -> int:
             action,
             client=client,
             yes=getattr(args, "yes", False),
-            timeout=getattr(args, "wait_timeout", PLAY_WAIT_TIMEOUT) + 240,
+            timeout=(
+                None
+                if action in {"pull", "play", "up", "recreate"}
+                else getattr(args, "wait_timeout", PLAY_WAIT_TIMEOUT) + 240
+            ),
             **options,
         )
         if action in {"play", "recreate"} and getattr(args, "open", False):

--- a/src/nitro_ai_judge_cli/play_legacy.py
+++ b/src/nitro_ai_judge_cli/play_legacy.py
@@ -47,7 +47,7 @@ def _docker(command: list[str]) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(command, 127, "", "")
 
 
-def discover_legacy_environments() -> list[dict[str, Any]]:
+def discover_legacy_environments(runtime: str = "docker") -> list[dict[str, Any]]:
     root = resolve_state_paths().play
     try:
         entries = sorted(os.scandir(root), key=lambda item: item.name)
@@ -71,7 +71,7 @@ def discover_legacy_environments() -> list[dict[str, Any]]:
         project = f"nitro-{org}-{competition}"
         listed = _docker(
             [
-                "docker",
+                runtime,
                 "ps",
                 "-a",
                 "--filter",
@@ -90,7 +90,7 @@ def discover_legacy_environments() -> list[dict[str, Any]]:
         workspace_volume = ""
         workspace_kind = "container-layer"
         if container_id:
-            inspected = _docker(["docker", "inspect", container_id])
+            inspected = _docker([runtime, "inspect", container_id])
             try:
                 mounts = json.loads(inspected.stdout)[0].get("Mounts") or []
             except (ValueError, IndexError, TypeError, json.JSONDecodeError):

--- a/src/nitro_ai_judge_cli/play_manager_client.py
+++ b/src/nitro_ai_judge_cli/play_manager_client.py
@@ -161,14 +161,14 @@ class ManagerClient:
         self,
         operation_id: str,
         *,
-        timeout: float = 600,
+        timeout: float | None = 600,
         interval: float = 0.5,
         progress: Callable[[dict[str, Any]], None] | None = None,
         stop_event: threading.Event | None = None,
     ) -> dict[str, Any]:
-        deadline = time.monotonic() + timeout
+        deadline = None if timeout is None else time.monotonic() + timeout
         last_sequence = -1
-        while time.monotonic() < deadline:
+        while deadline is None or time.monotonic() < deadline:
             if stop_event is not None and stop_event.is_set():
                 raise InterruptedError("Stopped waiting for Play operation")
             operation = self.operation(operation_id)
@@ -195,6 +195,7 @@ class ManagerClient:
                     raise InterruptedError("Stopped waiting for Play operation")
             else:
                 time.sleep(interval)
+        assert timeout is not None
         raise ManagerConnectionError(
             f"Play operation did not finish within {int(timeout)} seconds"
         )

--- a/src/nitro_ai_judge_cli/play_manager_lifecycle.py
+++ b/src/nitro_ai_judge_cli/play_manager_lifecycle.py
@@ -7,6 +7,7 @@ import json
 import os
 import platform
 import secrets
+import shutil
 import socket
 import subprocess
 import sys
@@ -39,6 +40,7 @@ class DockerEndpoint:
     host: str
     socket_source: str
     os_type: str
+    runtime: str = "docker"
 
 
 def run_process(
@@ -46,7 +48,7 @@ def run_process(
     *,
     check: bool = True,
     input_text: str | None = None,
-    timeout: float = 30,
+    timeout: float | None = 30,
 ) -> subprocess.CompletedProcess[str]:
     try:
         result = subprocess.run(
@@ -59,11 +61,11 @@ def run_process(
             timeout=timeout,
         )
     except FileNotFoundError as exc:
-        raise RuntimeError("Docker is not installed or not on PATH") from exc
+        raise RuntimeError(f"{command[0]} is not installed or not on PATH") from exc
     except subprocess.TimeoutExpired as exc:
         operation = " ".join(command[:3])
         raise RuntimeError(
-            f"Docker operation timed out after {timeout:g} seconds: {operation}"
+            f"Container operation timed out after {timeout:g} seconds: {operation}"
         ) from exc
     if check and result.returncode:
         details = (result.stderr or result.stdout or "").strip()
@@ -71,7 +73,54 @@ def run_process(
     return result
 
 
-def resolve_docker_endpoint() -> DockerEndpoint:
+def _validate_local_endpoint(
+    runtime: str, context: str, endpoint: str, os_type: str
+) -> DockerEndpoint:
+    display = runtime.capitalize()
+    if os_type and os_type != "linux":
+        raise RuntimeError(f"The Play manager requires {display} Linux containers")
+    if endpoint.startswith(("ssh://", "tcp://")):
+        raise RuntimeError(
+            f"{display} endpoint {context!r} is remote ({endpoint}); "
+            "the Play manager supports only a local runtime"
+        )
+    if endpoint.startswith("unix://"):
+        source = endpoint.removeprefix("unix://")
+        if not os.path.exists(source):
+            hint = (
+                "; start it with `systemctl --user enable --now podman.socket`"
+                if runtime == "podman"
+                else ""
+            )
+            raise RuntimeError(f"{display} socket does not exist: {source}{hint}")
+    elif endpoint.startswith("npipe://"):
+        if runtime != "docker" or platform.system() != "Windows":
+            raise RuntimeError(f"Unsupported {display} endpoint: {endpoint}")
+        source = "/var/run/docker.sock"
+    else:
+        raise RuntimeError(f"Unsupported {display} endpoint {endpoint!r}")
+    return DockerEndpoint(context, endpoint, source, os_type or "linux", runtime)
+
+
+def _resolve_podman_endpoint() -> DockerEndpoint:
+    run_process(["podman", "--version"])
+    run_process(["podman", "compose", "version"])
+    info = run_process(["podman", "info", "--format", "{{json .}}"])
+    try:
+        data = json.loads(info.stdout)
+        host = data.get("host") or {}
+        socket_path = str((host.get("remoteSocket") or {}).get("path") or "")
+        os_type = str(host.get("os") or "linux")
+    except (AttributeError, TypeError, json.JSONDecodeError):
+        socket_path, os_type = "", "linux"
+    configured = os.environ.get("CONTAINER_HOST", "").strip()
+    endpoint = configured or (f"unix://{socket_path}" if socket_path else "")
+    if not endpoint:
+        raise RuntimeError("Could not resolve the Podman API socket")
+    return _validate_local_endpoint("podman", "default", endpoint, os_type)
+
+
+def _resolve_docker_endpoint() -> DockerEndpoint:
     run_process(["docker", "--version"])
     run_process(["docker", "compose", "version"])
     context = run_process(["docker", "context", "show"]).stdout.strip() or "default"
@@ -81,35 +130,37 @@ def resolve_docker_endpoint() -> DockerEndpoint:
         endpoint = str(context_data["Endpoints"]["docker"]["Host"])
     except (KeyError, IndexError, TypeError, ValueError, json.JSONDecodeError) as exc:
         raise RuntimeError(f"Could not resolve Docker context {context!r}") from exc
-    configured = os.environ.get("DOCKER_HOST", "").strip()
-    if configured:
-        endpoint = configured
+    endpoint = os.environ.get("DOCKER_HOST", "").strip() or endpoint
     info = run_process(["docker", "info", "--format", "{{json .}}"])
     try:
         os_type = str(json.loads(info.stdout).get("OSType") or "")
     except (TypeError, json.JSONDecodeError):
         os_type = ""
-    if os_type and os_type != "linux":
-        raise RuntimeError(
-            "The Play manager requires Docker Desktop Linux containers; switch from Windows containers and retry"
-        )
-    if endpoint.startswith("ssh://") or endpoint.startswith("tcp://"):
-        raise RuntimeError(
-            f"Docker context {context!r} is remote ({endpoint}); the Play manager supports only a local Docker daemon"
-        )
-    if endpoint.startswith("unix://"):
-        source = endpoint.removeprefix("unix://")
-        if not os.path.exists(source):
-            raise RuntimeError(f"Docker socket does not exist: {source}")
-    elif endpoint.startswith("npipe://"):
-        if platform.system() != "Windows":
-            raise RuntimeError(f"Unsupported Docker endpoint: {endpoint}")
-        source = "/var/run/docker.sock"
+    return _validate_local_endpoint("docker", context, endpoint, os_type)
+
+
+def resolve_docker_endpoint(preferred_runtime: str | None = None) -> DockerEndpoint:
+    """Select Podman before Docker, unless an installation saved its runtime."""
+    resolvers = {
+        "podman": _resolve_podman_endpoint,
+        "docker": _resolve_docker_endpoint,
+    }
+    if preferred_runtime:
+        if preferred_runtime not in resolvers:
+            raise RuntimeError(f"Unsupported saved container runtime: {preferred_runtime}")
+        choices = (preferred_runtime,)
     else:
-        raise RuntimeError(
-            f"Unsupported Docker endpoint {endpoint!r}; select a local Unix-socket Docker context"
-        )
-    return DockerEndpoint(context, endpoint, source, os_type or "linux")
+        choices = ("podman", "docker")
+    errors: list[str] = []
+    for runtime in choices:
+        if shutil.which(runtime) is None:
+            continue
+        try:
+            return resolvers[runtime]()
+        except RuntimeError as exc:
+            errors.append(str(exc))
+    details = f" ({'; '.join(errors)})" if errors else ""
+    raise RuntimeError(f"Podman or Docker with Compose is required{details}")
 
 
 def manager_paths() -> dict[str, str]:
@@ -224,31 +275,30 @@ def generate_manager_compose(
             f"{health_url!r}, context=ssl._create_unverified_context(), timeout=2"
         )
     health_script += ")"
+    service: dict[str, Any] = {
+        "image": config["image"],
+        "restart": "unless-stopped",
+        "environment": environment,
+        "ports": [f"{bind}:{port}:51123"],
+        "volumes": volumes,
+        "secrets": service_secrets,
+        "networks": ["nitro"],
+        "labels": labels,
+        "healthcheck": {
+            "test": ["CMD", "python", "-c", health_script],
+            "interval": "5s",
+            "timeout": "3s",
+            "retries": 12,
+            "start_period": "5s",
+        },
+    }
+    if endpoint.runtime == "podman":
+        # Rootless Podman sockets cannot be relabelled for one container.
+        service["security_opt"] = ["label=disable"]
     return {
         "name": MANAGER_PROJECT,
         "services": {
-            "manager": {
-                "image": config["image"],
-                "restart": "unless-stopped",
-                "environment": environment,
-                "ports": [f"{bind}:{port}:51123"],
-                "volumes": volumes,
-                "secrets": service_secrets,
-                "networks": ["nitro"],
-                "labels": labels,
-                "healthcheck": {
-                    "test": [
-                        "CMD",
-                        "python",
-                        "-c",
-                        health_script,
-                    ],
-                    "interval": "5s",
-                    "timeout": "3s",
-                    "retries": 12,
-                    "start_period": "5s",
-                },
-            }
+            "manager": service
         },
         "volumes": {MANAGER_VOLUME: {"name": MANAGER_VOLUME, "labels": labels}},
         "networks": {
@@ -259,8 +309,10 @@ def generate_manager_compose(
 
 
 def _compose_command(*args: str) -> list[str]:
+    config = load_manager_config() or {}
+    runtime = str(config.get("container_runtime") or "docker")
     return [
-        "docker",
+        runtime,
         "compose",
         "--project-name",
         MANAGER_PROJECT,
@@ -329,12 +381,17 @@ def install_manager(
     validate_manager_exposure(
         bind, tls_cert=tls_cert, tls_key=tls_key, public_url=public_url
     )
-    endpoint = resolve_docker_endpoint()
+    old_config = load_manager_config()
+    saved_runtime = (
+        str(old_config.get("container_runtime") or "docker")
+        if old_config is not None
+        else None
+    )
+    endpoint = resolve_docker_endpoint(saved_runtime)
     paths = manager_paths()
     ensure_state_dir()
     os.makedirs(paths["root"], mode=0o700, exist_ok=True)
     os.chmod(paths["root"], 0o700)
-    old_config = load_manager_config()
     old_compose = None
     try:
         with open(paths["compose"], "rb") as stream:
@@ -390,11 +447,14 @@ def install_manager(
         "dashboard_token": bool(lan),
         "docker_context": endpoint.context,
         "docker_host": endpoint.host,
+        "container_runtime": endpoint.runtime,
     }
     compose = generate_manager_compose(config, endpoint)
-    image_present = run_process(["docker", "image", "inspect", image], check=False).returncode == 0
+    image_present = run_process(
+        [endpoint.runtime, "image", "inspect", image], check=False
+    ).returncode == 0
     if update or not image_present:
-        run_process(["docker", "pull", image], timeout=1800)
+        run_process([endpoint.runtime, "pull", image], timeout=None)
     try:
         atomic_write(
             paths["config"],
@@ -409,7 +469,7 @@ def install_manager(
         sync_manager_credentials(required=False)
         from .play_legacy import discover_legacy_environments
 
-        manifests = discover_legacy_environments()
+        manifests = discover_legacy_environments(endpoint.runtime)
         if manifests:
             ManagerClient.from_state().adopt_legacy(manifests)
         return info
@@ -473,8 +533,9 @@ def purge_manager_state(*, force: bool = False) -> None:
     if not force:
         raise RuntimeError("Purging manager-private state requires --force")
     uninstall_manager()
+    runtime = str((load_manager_config() or {}).get("container_runtime") or "docker")
     inspected = run_process(
-        ["docker", "volume", "inspect", MANAGER_VOLUME], check=False
+        [runtime, "volume", "inspect", MANAGER_VOLUME], check=False
     )
     if inspected.returncode == 0:
         try:
@@ -485,7 +546,7 @@ def purge_manager_state(*, force: bool = False) -> None:
             raise RuntimeError(
                 f"Refusing to remove volume {MANAGER_VOLUME}: ownership label is missing"
             )
-        run_process(["docker", "volume", "rm", MANAGER_VOLUME], timeout=60)
+        run_process([runtime, "volume", "rm", MANAGER_VOLUME], timeout=60)
 
 
 def normalized_credentials(value: dict[str, Any]) -> dict[str, Any]:

--- a/src/nitro_ai_judge_cli/play_protocol.py
+++ b/src/nitro_ai_judge_cli/play_protocol.py
@@ -10,12 +10,12 @@ from typing import Any
 
 API_VERSION = 1
 MANAGER_IDENTITY = "naij-play-manager"
-MANAGER_VERSION = "3.1.4"
+MANAGER_VERSION = "3.1.5"
 MINIMUM_CLI_VERSION = "3.0.0"
 DEFAULT_MANAGER_BIND = "127.0.0.1"
 DEFAULT_MANAGER_PORT = 51123
 DEFAULT_MANAGER_IMAGE = (
-    "ghcr.io/mihneateodorstoica/naij-play-manager:3.1.4"
+    "ghcr.io/mihneateodorstoica/naij-play-manager:3.1.5"
 )
 BASE_PATH = "/nitro"
 

--- a/src/nitro_ai_judge_cli/tui.py
+++ b/src/nitro_ai_judge_cli/tui.py
@@ -250,7 +250,7 @@ def _load_submission_with_auth(
 
 
 async def _wait_for_play_operation(
-    client: ManagerClient, operation_id: str, *, timeout: float
+    client: ManagerClient, operation_id: str, *, timeout: float | None
 ) -> dict[str, Any]:
     stop_event = threading.Event()
     loop = asyncio.get_running_loop()
@@ -2511,7 +2511,7 @@ class NitroTUI(App[int]):
                 await _wait_for_play_operation(
                     client,
                     str(accepted["operation_id"]),
-                    timeout=600,
+                    timeout=None if action in {"pull", "play", "recreate"} else 600,
                 )
             self.set_status(f"Play {action} completed.", "success")
             self.refresh_play_status()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -784,6 +784,7 @@ class ManagerBackendSafetyTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(
             any("elapsed" in call.args[1] for call in progress.await_args_list)
         )
+        self.assertIsNone(self.backend.run.await_args.kwargs["timeout"])
 
     async def test_cancelling_pull_terminates_docker_process(self) -> None:
         class HangingProcess:

--- a/tests/test_play.py
+++ b/tests/test_play.py
@@ -548,6 +548,39 @@ class ManagerConfigurationTests(unittest.TestCase):
         state.configure_state_dir(None)
         self.tempdir.cleanup()
 
+    def test_runtime_resolution_prefers_working_podman_then_docker(self) -> None:
+        podman = DockerEndpoint(
+            "default", "unix:///run/podman.sock", "/run/podman.sock", "linux", "podman"
+        )
+        docker = DockerEndpoint(
+            "default", "unix:///run/docker.sock", "/run/docker.sock", "linux"
+        )
+        with (
+            patch.object(play_manager_lifecycle.shutil, "which", return_value="/bin/runtime"),
+            patch.object(
+                play_manager_lifecycle, "_resolve_podman_endpoint", return_value=podman
+            ) as resolve_podman,
+            patch.object(
+                play_manager_lifecycle, "_resolve_docker_endpoint", return_value=docker
+            ) as resolve_docker,
+        ):
+            self.assertEqual(play_manager_lifecycle.resolve_docker_endpoint(), podman)
+        resolve_podman.assert_called_once_with()
+        resolve_docker.assert_not_called()
+
+        with (
+            patch.object(play_manager_lifecycle.shutil, "which", return_value="/bin/runtime"),
+            patch.object(
+                play_manager_lifecycle,
+                "_resolve_podman_endpoint",
+                side_effect=RuntimeError("Podman socket missing"),
+            ),
+            patch.object(
+                play_manager_lifecycle, "_resolve_docker_endpoint", return_value=docker
+            ),
+        ):
+            self.assertEqual(play_manager_lifecycle.resolve_docker_endpoint(), docker)
+
     def test_compose_uses_secret_file_socket_network_and_labels(self) -> None:
         paths = state.ensure_state_dir().play_manager
         os.makedirs(paths)
@@ -574,6 +607,34 @@ class ManagerConfigurationTests(unittest.TestCase):
             service["labels"]["org.nitro-ai.naij.play.owner"], "naij-play-manager"
         )
         self.assertNotIn("private", json.dumps(compose))
+
+    def test_podman_compose_disables_selinux_relabelling_for_socket(self) -> None:
+        paths = state.ensure_state_dir().play_manager
+        os.makedirs(paths)
+        with open(os.path.join(paths, "cli-api-token"), "w", encoding="utf-8") as stream:
+            stream.write("private")
+        config = {
+            "bind": "127.0.0.1",
+            "port": 51123,
+            "public_url": "http://localhost:51123",
+            "image": "manager:test",
+            "tls_cert": None,
+            "tls_key": None,
+            "dashboard_token": False,
+        }
+        endpoint = DockerEndpoint(
+            "default",
+            "unix:///run/user/1000/podman/podman.sock",
+            "/run/user/1000/podman/podman.sock",
+            "linux",
+            "podman",
+        )
+        service = generate_manager_compose(config, endpoint)["services"]["manager"]
+        self.assertEqual(service["security_opt"], ["label=disable"])
+        self.assertIn(
+            "/run/user/1000/podman/podman.sock:/var/run/docker.sock",
+            service["volumes"],
+        )
 
     def test_tls_healthcheck_uses_https_without_loopback_verification(self) -> None:
         paths = state.ensure_state_dir().play_manager
@@ -745,6 +806,16 @@ class ManagerClientTests(unittest.TestCase):
         ):
             client.wait_operation("operation", stop_event=stop_event)
         operation.assert_not_called()
+
+    def test_wait_operation_can_wait_without_a_deadline(self) -> None:
+        client = ManagerClient("http://localhost", "token")
+        with patch.object(
+            client,
+            "operation",
+            side_effect=[{"status": "running"}, {"status": "complete", "result": {}}],
+        ):
+            operation = client.wait_operation("operation", timeout=None, interval=0)
+        self.assertEqual(operation["status"], "complete")
 
     def test_follow_logs_decodes_ndjson_to_plain_lines(self) -> None:
         class Response(list):

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -19,13 +19,13 @@ from nitro_ai_judge_cli.play_protocol import (
 
 
 class ReleaseTests(unittest.TestCase):
-    def test_3_1_4_versions_keep_protocol_compatibility(self) -> None:
+    def test_3_1_5_versions_keep_protocol_compatibility(self) -> None:
         pyproject = Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
-        self.assertIn('version = "3.1.4"', pyproject)
-        self.assertEqual(MANAGER_VERSION, "3.1.4")
+        self.assertIn('version = "3.1.5"', pyproject)
+        self.assertEqual(MANAGER_VERSION, "3.1.5")
         self.assertEqual(
             DEFAULT_MANAGER_IMAGE,
-            "ghcr.io/mihneateodorstoica/naij-play-manager:3.1.4",
+            "ghcr.io/mihneateodorstoica/naij-play-manager:3.1.5",
         )
         self.assertEqual(API_VERSION, 1)
         self.assertEqual(MINIMUM_CLI_VERSION, "3.0.0")
@@ -117,7 +117,7 @@ class ReleaseTests(unittest.TestCase):
                     patch.object(
                         play,
                         "install_manager",
-                        return_value={"manager_version": "3.1.4"},
+                        return_value={"manager_version": "3.1.5"},
                     ) as install,
                     patch("builtins.print"),
                 ):

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "nitro-ai-judge-cli"
-version = "3.1.4"
+version = "3.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "textual" },


### PR DESCRIPTION
## Summary
- prefer a working Podman + Compose runtime, with Docker fallback for new Play manager installs
- preserve the runtime selected by existing installations
- remove fixed manager and competition image-pull deadlines while retaining cancellation and service-readiness timeouts
- bump CLI and manager image versions to 3.1.5

## Validation
- `uv run --extra manager python -m unittest discover -s tests -q` (286 tests, 3 skipped)
- Podman manager integration suite (2 tests)
- package build and `twine check dist/*`
- implementation commit is GitHub-verified